### PR TITLE
Update logpoll interval for bsc testnet

### DIFF
--- a/pkg/config/toml/defaults/BSC_Testnet.toml
+++ b/pkg/config/toml/defaults/BSC_Testnet.toml
@@ -4,7 +4,7 @@
 ChainID = '97'
 FinalityTagEnabled = true
 LinkContractAddress = '0x84b9B910527Ad5C03A9Ca831909E21e236EA7b06'
-LogPollInterval = '3s'
+LogPollInterval = '1.5s'
 NoNewHeadsThreshold = '30s'
 RPCBlockQueryDelay = 2
 FinalizedBlockOffset = 2


### PR DESCRIPTION
**What**
Update BSC Testnet Config

**Why**
The upcoming BSC Testnet Lorentz hard fork activates on 2025-04-08 07:33:00 AM UTC and lowers the block rate from 3 to 1.5 seconds.

See https://github.com/bnb-chain/bsc/releases/tag/v1.5.9