### PR TITLE
fixed broken link in `FOUNDRY_GUIDE.md`

### DIFF
--- a/contracts/FOUNDRY_GUIDE.md
+++ b/contracts/FOUNDRY_GUIDE.md
@@ -200,7 +200,7 @@ Focus on unit tests before exploring more advanced testing.
 
 ## Best practices
 
-Check out the official [Foundry best practices section](https://book.getfoundry.sh/tutorials/best-practices).
+Check out the official [Foundry best practices section](https://book.getfoundry.sh/guides/best-practices).
 
 - There should be no code between `vm.expectEmit`/`vm.expectRevert` and the function call.
   - Test setup should be done before the `vm.expect` call.


### PR DESCRIPTION
Hi, just patched a dead link in the Best Practices section —  updated the URL to point to the current `guides/best-practices` path in the Foundry book.

Docs-only fix to improve navigation for devs following along.