### PR TITLE
[BCFR-1441] Subtract 2 from configured rpcBatchSize to account for ref blocks

### DIFF
--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -1420,7 +1420,7 @@ func (lp *logPoller) fillRemainingBlocksFromRPC(
 			"remainingBlocks", remainingBlocks)
 	}
 
-	return lp.batchFetchBlocks(ctx, remainingBlocks, lp.rpcBatchSize)
+	return lp.batchFetchBlocks(ctx, remainingBlocks, lp.rpcBatchSize-2) // subtract 2 to leave room for 2 reference requests added in lp.fetchBlocks()
 }
 
 // newBlockReq constructs an eth_getBlockByNumber request for particular block number

--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -1420,7 +1420,12 @@ func (lp *logPoller) fillRemainingBlocksFromRPC(
 			"remainingBlocks", remainingBlocks)
 	}
 
-	return lp.batchFetchBlocks(ctx, remainingBlocks, lp.rpcBatchSize-2) // subtract 2 to leave room for 2 reference requests added in lp.fetchBlocks()
+	batchSize := lp.rpcBatchSize - 2 // subtract 2 to leave room for 2 reference requests added in lp.fetchBlocks()
+	if batchSize < 1 {
+		batchSize = 1
+	}
+
+	return lp.batchFetchBlocks(ctx, remainingBlocks, batchSize)
 }
 
 // newBlockReq constructs an eth_getBlockByNumber request for particular block number


### PR DESCRIPTION
If you configure it to match the rpc server's limit on batch size, it shouldn't error out. This was happening for an rpc server which had a limit of 100, it was sending 102 even after setting DefaultRPCBatchSize=100 in toml, due to the 2 extra requests we append to each batch after batching.