### PR TITLE
Return Transaction Fee with Capability Response

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -64,6 +64,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
+      - name: Install asdf and Plugins
+        uses: asdf-vm/actions/plugins-add@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
+        with:
+          asdf_branch: v0.16.7
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+golang 1.24.2
+protoc 29.3
+starknet-foundry 1.0.0

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <div align="center">
-  <h1>Chainlink EVM</h1>
   <a><img src="https://raw.githubusercontent.com/smartcontractkit/chainlink/develop/docs/logo-chainlink-blue.svg" /></a>
   <br/>
   <br/>
 </div>
+
+# Chainlink EVM
 
 This repository contains EVM related services and contracts relating to Chainlink services.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+<div align="center">
+  <h1>Chainlink EVM</h1>
+  <a><img src="https://raw.githubusercontent.com/smartcontractkit/chainlink/develop/docs/logo-chainlink-blue.svg" /></a>
+  <br/>
+  <br/>
+</div>
+
+This repository contains EVM related services and contracts relating to Chainlink services.
+
+## Development
+
+### Getting Started
+
+#### Setup
+
+[asdf](https://asdf-vm.com/) is a tool version manager. All dependencies used for local development of this repo are
+managed through `asdf`. To install `asdf`:
+
+1. [Install asdf](https://asdf-vm.com/guide/getting-started.html)
+2. Follow the instructions to ensure `asdf` is shimmed into your terminal or development environment
+
+#### Installing Dependencies
+
+Install the required tools using [asdf](https://asdf-vm.com/guide/getting-started.html):
+
+```bash
+./scripts/setup-asdf-plugin.sh
+asdf install
+```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink-evm
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/ethereum/go-ethereum v1.15.3

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,15 +1,18 @@
 .PHONY: mockery
 mockery: ## Install mockery.
-	go install github.com/vektra/mockery/v2@v2.53.3
+	go install github.com/vektra/mockery/v2@v2.53.3 \
+	asdf reshim golang
 
 .PHONY: codecgen
 codecgen: ## Install codecgen
-	go install github.com/ugorji/go/codec/codecgen@v1.2.10
+	go install github.com/ugorji/go/codec/codecgen@v1.2.10 \
+	asdf reshim golang
 
 .PHONY: protoc
 protoc: ## Install protoc
 	../tools/bin/install-protoc.sh 29.3 /
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@`go list -m -json google.golang.org/protobuf | jq -r .Version`
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@`go list -m -json google.golang.org/protobuf | jq -r .Version` \
+	asdf reshim golang
 
 .PHONY: generate
 generate: codecgen mockery protoc

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,17 +1,17 @@
 .PHONY: mockery
 mockery: ## Install mockery.
-	go install github.com/vektra/mockery/v2@v2.53.3 \
+	go install github.com/vektra/mockery/v2@v2.53.3 && \
 	asdf reshim golang
 
 .PHONY: codecgen
 codecgen: ## Install codecgen
-	go install github.com/ugorji/go/codec/codecgen@v1.2.10 \
+	go install github.com/ugorji/go/codec/codecgen@v1.2.10 && \
 	asdf reshim golang
 
 .PHONY: protoc
 protoc: ## Install protoc
 	../tools/bin/install-protoc.sh 29.3 /
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@`go list -m -json google.golang.org/protobuf | jq -r .Version` \
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@`go list -m -json google.golang.org/protobuf | jq -r .Version` && \
 	asdf reshim golang
 
 .PHONY: generate

--- a/pkg/writetarget/write_target.go
+++ b/pkg/writetarget/write_target.go
@@ -358,6 +358,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 
 	fee, err := c.evm.GetTransactionFee(ctx, txID)
 	if err != nil {
+		fee = &commontypes.TransactionFee{TransactionFee: new(big.Int)}
 		c.lggr.Errorw("failed to get transaction fee for transaction id", "err", err, "txid", txID)
 	}
 

--- a/pkg/writetarget/write_target.go
+++ b/pkg/writetarget/write_target.go
@@ -7,11 +7,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/assets"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities"
 	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -87,6 +89,7 @@ type writeTarget struct {
 
 	nodeAddress      string
 	forwarderAddress string
+	p2pID            string
 
 	targetStrategy TargetStrategy
 }
@@ -160,12 +163,33 @@ func NewWriteTarget(opts WriteTargetOpts) capabilities.TargetCapability {
 		opts.ConfigValidateFn,
 		opts.NodeAddress,
 		opts.ForwarderAddress,
+		opts.ID,
 		opts.TargetStrategy,
 	}
 }
 
-func success() capabilities.CapabilityResponse {
+func failure() capabilities.CapabilityResponse {
 	return capabilities.CapabilityResponse{}
+}
+
+func success(p2pID string, transactionFee *big.Int) capabilities.CapabilityResponse {
+	var detail []capabilities.MeteringNodeDetail
+
+	if transactionFee != nil {
+		detail = []capabilities.MeteringNodeDetail{
+			{
+				Peer2PeerID: p2pID,
+				SpendUnit:   "ETH",
+				SpendValue:  assets.Format(transactionFee, 18), // convert wei to ETH
+			},
+		}
+	}
+
+	return capabilities.CapabilityResponse{
+		Metadata: capabilities.ResponseMetadata{
+			Metering: detail,
+		},
+	}
 }
 
 func (c *writeTarget) Execute(ctx context.Context, request capabilities.CapabilityRequest) (capabilities.CapabilityResponse, error) {
@@ -204,7 +228,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	receiver, err := c.configValidateFn(request)
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to validate config", err.Error())
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	}
 
 	// Source the receiver address from the config
@@ -215,14 +239,14 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	if !ok {
 		cause := fmt.Sprintf("input missing required field: '%s'", KeySignedReport)
 		msg := builder.buildWriteError(info, 0, "failed to source the signed report", cause)
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	}
 
 	// Decode the signed report
 	inputs := types.SignedReport{}
 	if err = signedReport.UnwrapTo(&inputs); err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to parse signed report", err.Error())
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	}
 
 	// Source the report ID from the input
@@ -241,7 +265,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 		if err != nil {
 			c.lggr.Errorw("failed to emit write skipped", "err", err)
 		}
-		return success(), nil
+		return success("", nil), nil
 	}
 
 	// Update the info with the report info
@@ -256,16 +280,16 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	reportDecoded, err := platform.Decode(inputs.Report)
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to decode the report", err.Error())
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	}
 
 	// Validate encoded report is prefixed with workflowID and executionID that match the request meta
 	if reportDecoded.ExecutionID != request.Metadata.WorkflowExecutionID {
 		msg := builder.buildWriteError(info, 0, "decoded report execution ID does not match the request", "")
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	} else if reportDecoded.WorkflowID != request.Metadata.WorkflowID {
 		msg := builder.buildWriteError(info, 0, "decoded report workflow ID does not match the request", "")
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	}
 
 	// Fetch the latest head from the chain (timestamp), retry with a default backoff strategy
@@ -273,7 +297,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	head, err := retry.With(ctx, c.lggr, c.cs.LatestHead)
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to fetch the latest head", err.Error())
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	}
 
 	c.lggr.Debugw("non-empty valid report",
@@ -291,7 +315,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to fetch [TransmissionState]", err.Error())
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	}
 
 	switch state.Status {
@@ -301,7 +325,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 		c.lggr.Debugw("Tranmissions previously failed, retrying", "reportID", info.reportInfo.reportID)
 	case TransmissionStateFatal:
 		msg := builder.buildWriteError(info, 0, "Transmission attempt fatal", state.Err.Error())
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	case TransmissionStateSucceeded:
 		// Source the transmitter address from the on-chain state
 		info.reportTransmissionState = state
@@ -310,7 +334,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 		if err != nil {
 			c.lggr.Errorw("failed to emit write confirmed", "err", err)
 		}
-		return success(), nil
+		return success("", nil), nil
 	}
 
 	c.lggr.Infow("on-chain report check done - attempting to push to txmgr",
@@ -325,7 +349,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	c.lggr.Debugw("Transaction submitted", "request", request, "transaction-id", txID)
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to transmit the report", err.Error())
-		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
+		return failure(), c.asEmittedError(ctx, msg)
 	}
 	err = c.beholder.ProtoEmitter.EmitWithLog(ctx, builder.buildWriteSent(info, head, txID))
 	if err != nil {
@@ -336,7 +360,13 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	// relevant to this forwarder), and emit write-tx-accepted/confirmed events.
 
 	go c.acceptAndConfirmWrite(ctx, *info, txID)
-	return success(), nil
+
+	fee, err := c.evm.GetTransactionFee(ctx, txID)
+	if err != nil {
+		c.lggr.Errorw("failed to get transaction fee for transaction id", "err", err, "txid", txID)
+	}
+
+	return success(c.p2pID, fee.TransactionFee), nil
 }
 
 func (c *writeTarget) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {

--- a/pkg/writetarget/write_target.go
+++ b/pkg/writetarget/write_target.go
@@ -168,19 +168,14 @@ func NewWriteTarget(opts WriteTargetOpts) capabilities.TargetCapability {
 	}
 }
 
-func failure() capabilities.CapabilityResponse {
-	return capabilities.CapabilityResponse{}
-}
-
-func success(p2pID string, transactionFee *big.Int) capabilities.CapabilityResponse {
+func success(transactionFee *big.Int) capabilities.CapabilityResponse {
 	var detail []capabilities.MeteringNodeDetail
 
 	if transactionFee != nil {
 		detail = []capabilities.MeteringNodeDetail{
 			{
-				Peer2PeerID: p2pID,
-				SpendUnit:   "ETH",
-				SpendValue:  assets.Format(transactionFee, 18), // convert wei to ETH
+				SpendUnit:  "ETH",
+				SpendValue: assets.Format(transactionFee, 18), // convert wei to ETH
 			},
 		}
 	}
@@ -228,7 +223,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	receiver, err := c.configValidateFn(request)
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to validate config", err.Error())
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	}
 
 	// Source the receiver address from the config
@@ -239,14 +234,14 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	if !ok {
 		cause := fmt.Sprintf("input missing required field: '%s'", KeySignedReport)
 		msg := builder.buildWriteError(info, 0, "failed to source the signed report", cause)
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	}
 
 	// Decode the signed report
 	inputs := types.SignedReport{}
 	if err = signedReport.UnwrapTo(&inputs); err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to parse signed report", err.Error())
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	}
 
 	// Source the report ID from the input
@@ -265,7 +260,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 		if err != nil {
 			c.lggr.Errorw("failed to emit write skipped", "err", err)
 		}
-		return success("", nil), nil
+		return capabilities.CapabilityResponse{}, nil
 	}
 
 	// Update the info with the report info
@@ -280,16 +275,16 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	reportDecoded, err := platform.Decode(inputs.Report)
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to decode the report", err.Error())
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	}
 
 	// Validate encoded report is prefixed with workflowID and executionID that match the request meta
 	if reportDecoded.ExecutionID != request.Metadata.WorkflowExecutionID {
 		msg := builder.buildWriteError(info, 0, "decoded report execution ID does not match the request", "")
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	} else if reportDecoded.WorkflowID != request.Metadata.WorkflowID {
 		msg := builder.buildWriteError(info, 0, "decoded report workflow ID does not match the request", "")
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	}
 
 	// Fetch the latest head from the chain (timestamp), retry with a default backoff strategy
@@ -297,7 +292,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	head, err := retry.With(ctx, c.lggr, c.cs.LatestHead)
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to fetch the latest head", err.Error())
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	}
 
 	c.lggr.Debugw("non-empty valid report",
@@ -315,7 +310,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to fetch [TransmissionState]", err.Error())
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	}
 
 	switch state.Status {
@@ -325,7 +320,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 		c.lggr.Debugw("Tranmissions previously failed, retrying", "reportID", info.reportInfo.reportID)
 	case TransmissionStateFatal:
 		msg := builder.buildWriteError(info, 0, "Transmission attempt fatal", state.Err.Error())
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	case TransmissionStateSucceeded:
 		// Source the transmitter address from the on-chain state
 		info.reportTransmissionState = state
@@ -334,7 +329,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 		if err != nil {
 			c.lggr.Errorw("failed to emit write confirmed", "err", err)
 		}
-		return success("", nil), nil
+		return capabilities.CapabilityResponse{}, nil
 	}
 
 	c.lggr.Infow("on-chain report check done - attempting to push to txmgr",
@@ -349,7 +344,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 	c.lggr.Debugw("Transaction submitted", "request", request, "transaction-id", txID)
 	if err != nil {
 		msg := builder.buildWriteError(info, 0, "failed to transmit the report", err.Error())
-		return failure(), c.asEmittedError(ctx, msg)
+		return capabilities.CapabilityResponse{}, c.asEmittedError(ctx, msg)
 	}
 	err = c.beholder.ProtoEmitter.EmitWithLog(ctx, builder.buildWriteSent(info, head, txID))
 	if err != nil {
@@ -366,7 +361,7 @@ func (c *writeTarget) Execute(ctx context.Context, request capabilities.Capabili
 		c.lggr.Errorw("failed to get transaction fee for transaction id", "err", err, "txid", txID)
 	}
 
-	return success(c.p2pID, fee.TransactionFee), nil
+	return success(fee.TransactionFee), nil
 }
 
 func (c *writeTarget) RegisterToWorkflow(ctx context.Context, request capabilities.RegisterToWorkflowRequest) error {

--- a/scripts/setup-asdf-plugin.sh
+++ b/scripts/setup-asdf-plugin.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Define the plugins and their respective repositories
+declare -A plugins
+plugins=(
+  ["golang"]="https://github.com/asdf-community/asdf-golang.git"
+  ["protoc"]="https://github.com/paxosglobal/asdf-protoc.git"
+  ["starknet-foundry"]="https://github.com/foundry-rs/asdf-starknet-foundry.git"
+)
+
+# Read the .tool-versions file and install the plugins
+while read -r line; do
+  plugin=$(echo "$line" | awk '{print $1}')
+  version=$(echo "$line" | awk '{print $2}')
+
+  if [[ -n "${plugins[$plugin]}" ]]; then
+    echo "Installing $plugin $version..."
+    asdf plugin add "$plugin" "${plugins[$plugin]}"
+  else
+    echo "No repository URL found for plugin $plugin. Skipping..."
+  fi
+done < .tool-versions
+
+echo "All plugins installed successfully."


### PR DESCRIPTION
This commit links the transaction fee data return by an EVMService to a `CapabilityResponse` within the write target. The intention is to surface transaction costs for billing purposes.

Additionally, this commit adds tool setup scripts streamlined with `asdf`.