### PR TITLE
LogPoller: Add reporting of missing blocks errors for hyperliquid chain

### DIFF
--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -65,6 +65,7 @@ const (
 	TerminallyStuck
 	TooManyResults
 	ServiceTimeout
+	MissingBlocks
 )
 
 type ClientErrors map[int]*regexp.Regexp
@@ -330,6 +331,7 @@ func ClientErrorRegexes(errsRegex config.ClientErrors) *ClientErrors {
 		Fatal:                             regexp.MustCompile(errsRegex.Fatal()),
 		ServiceUnavailable:                regexp.MustCompile(errsRegex.ServiceUnavailable()),
 		TooManyResults:                    regexp.MustCompile(errsRegex.TooManyResults()),
+		MissingBlocks:                     regexp.MustCompile(errsRegex.MissingBlocks()),
 	}
 }
 
@@ -691,9 +693,14 @@ var drpc = ClientErrors{
 	TooManyResults: regexp.MustCompile(`(: |^)requested too many blocks from [0-9]+ to [0-9]+, maximum is set to [0-9,]+$`),
 }
 
+var hyperliquid = ClientErrors{
+	TooManyResults: regexp.MustCompile(`(: |^)query exceeds max block range$`),
+	MissingBlocks:  regexp.MustCompile(`(: |^)invalid block range$`),
+}
+
 // Linkpool, Blockdaemon, and Chainstack all return "request timed out" if the log results are too large for them to process
 var defaultClient = ClientErrors{
-	TooManyResults: regexp.MustCompile(`request timed out|408 Request Timed Out`),
+	TooManyResults: regexp.MustCompile(`request timed out|408 Request Timed Out$`),
 }
 
 // JSON-RPC error codes which can indicate a refusal of the server to process an eth_getLogs request because the result set is too large
@@ -712,7 +719,7 @@ const (
 	// See: https://community.infura.io/t/getlogs-error-query-returned-more-than-1000-results/358/5
 	jsonRpcLimitExceeded = -32005 // See also: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
 
-	jsonRpcInvalidParams = -32602 // Invalid method params. Returned by alchemy if the block range is too large or there are too many results to return
+	jsonRpcInvalidParams = -32602 // Invalid method params. Returned by alchemy if the block range is too large or there are too many results to return. Also returned by hyperliquid for invalid block range or block range too large
 
 	jsonRpcQuicknodeTooManyResults = -32614 // Undocumented error code used by Quicknode for too many results error
 )
@@ -743,6 +750,9 @@ func IsTooManyResults(err error, clientErrors config.ClientErrors) bool {
 		if alchemy.ErrIs(rpcErr, TooManyResults) {
 			return true
 		}
+		if hyperliquid.ErrIs(rpcErr, TooManyResults) {
+			return true
+		}
 	case jsonRpcQuicknodeTooManyResults:
 		if quicknode.ErrIs(rpcErr, TooManyResults) {
 			return true
@@ -756,6 +766,24 @@ func IsTooManyResults(err error, clientErrors config.ClientErrors) bool {
 			drpc.ErrIs(rpcErr, TooManyResults) {
 			return true
 		}
+	}
+	return false
+}
+
+// IsMissingBlocks indicates that the error is caused by the rpc server not having some of the blocks requested at all
+// This is treated as a permanent error rather than a transient issue, and should be logged as Critical
+func IsMissingBlocks(err error, clientErrors config.ClientErrors) bool {
+	var rpcErr rpc.Error
+	if !pkgerrors.As(err, &rpcErr) {
+		return false
+	}
+	configErrors := ClientErrorRegexes(clientErrors)
+	if configErrors.ErrIs(rpcErr, MissingBlocks) {
+		return true
+	}
+
+	if rpcErr.ErrorCode() == jsonRpcInvalidParams && hyperliquid.ErrIs(rpcErr, MissingBlocks) {
+		return true
 	}
 	return false
 }

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -705,23 +705,23 @@ var defaultClient = ClientErrors{
 
 // JSON-RPC error codes which can indicate a refusal of the server to process an eth_getLogs request because the result set is too large
 const (
-	jsonRpcServerError = -32000 // Server error. SimplyVC uses this error code when too many results are returned
+	jsonRPCServerError = -32000 // Server error. SimplyVC uses this error code when too many results are returned
 
 	// Server timeout. When the rpc server has its own limit on how long it can take to compile the results
 	// Examples: Linkpool, Chainstack, Block Daemon
-	jsonRpcTimedOut = -32002
+	jsonRPCTimedOut = -32002
 
 	// See: https://github.com/ethereum/go-ethereum/blob/master/rpc/errors.go#L63
 	// Can occur if the rpc server is configured with a maximum byte limit on the response size of batch requests
-	jsonRpcResponseTooLarge = -32003
+	jsonRPCResponseTooLarge = -32003
 
 	// Not implemented in geth by default, but is defined in EIP 1474 and implemented by infura and some other 3rd party rpc servers
 	// See: https://community.infura.io/t/getlogs-error-query-returned-more-than-1000-results/358/5
-	jsonRpcLimitExceeded = -32005 // See also: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
+	jsonRPCLimitExceeded = -32005 // See also: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
 
-	jsonRpcInvalidParams = -32602 // Invalid method params. Returned by alchemy if the block range is too large or there are too many results to return. Also returned by hyperliquid for invalid block range or block range too large
+	jsonRPCInvalidParams = -32602 // Invalid method params. Returned by alchemy if the block range is too large or there are too many results to return. Also returned by hyperliquid for invalid block range or block range too large
 
-	jsonRpcQuicknodeTooManyResults = -32614 // Undocumented error code used by Quicknode for too many results error
+	jsonRPCQuicknodeTooManyResults = -32614 // Undocumented error code used by Quicknode for too many results error
 )
 
 func IsTooManyResults(err error, clientErrors config.ClientErrors) bool {
@@ -740,28 +740,28 @@ func IsTooManyResults(err error, clientErrors config.ClientErrors) bool {
 	}
 
 	switch rpcErr.ErrorCode() {
-	case jsonRpcResponseTooLarge:
+	case jsonRPCResponseTooLarge:
 		return true
-	case jsonRpcLimitExceeded:
+	case jsonRPCLimitExceeded:
 		if infura.ErrIs(rpcErr, TooManyResults) {
 			return true
 		}
-	case jsonRpcInvalidParams:
+	case jsonRPCInvalidParams:
 		if alchemy.ErrIs(rpcErr, TooManyResults) {
 			return true
 		}
 		if hyperliquid.ErrIs(rpcErr, TooManyResults) {
 			return true
 		}
-	case jsonRpcQuicknodeTooManyResults:
+	case jsonRPCQuicknodeTooManyResults:
 		if quicknode.ErrIs(rpcErr, TooManyResults) {
 			return true
 		}
-	case jsonRpcTimedOut:
+	case jsonRPCTimedOut:
 		if defaultClient.ErrIs(rpcErr, TooManyResults) {
 			return true
 		}
-	case jsonRpcServerError:
+	case jsonRPCServerError:
 		if simplyvc.ErrIs(rpcErr, TooManyResults) ||
 			drpc.ErrIs(rpcErr, TooManyResults) {
 			return true
@@ -782,7 +782,7 @@ func IsMissingBlocks(err error, clientErrors config.ClientErrors) bool {
 		return true
 	}
 
-	if rpcErr.ErrorCode() == jsonRpcInvalidParams && hyperliquid.ErrIs(rpcErr, MissingBlocks) {
+	if rpcErr.ErrorCode() == jsonRPCInvalidParams && hyperliquid.ErrIs(rpcErr, MissingBlocks) {
 		return true
 	}
 	return false

--- a/pkg/client/errors_test.go
+++ b/pkg/client/errors_test.go
@@ -562,10 +562,10 @@ func Test_IsTooManyResultsError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.network, func(t *testing.T) {
-			jsonRpcErr := evmclient.JsonError{}
-			err := json.Unmarshal([]byte(test.message), &jsonRpcErr)
+			jsonRPCErr := evmclient.JsonError{}
+			err := json.Unmarshal([]byte(test.message), &jsonRPCErr)
 			if err == nil {
-				err = jsonRpcErr
+				err = jsonRPCErr
 			}
 			assert.Equal(t, test.expect, evmclient.IsTooManyResults(err, &customErrors))
 		})
@@ -574,4 +574,36 @@ func Test_IsTooManyResultsError(t *testing.T) {
 	t.Run("Context DeadlineExceeded is TooManyResults", func(t *testing.T) {
 		assert.True(t, evmclient.IsTooManyResults(context.DeadlineExceeded, nil))
 	})
+}
+
+func Test_IsMissingBlocksError(t *testing.T) {
+	customErrors := evmclient.NewTestClientErrors()
+
+	tests := []errorCase{{`{
+		"code":-32602",
+		"message":"unrelated invalid params error"}`,
+		false,
+		"generic invalid params error",
+	}, {`{
+		"code":-32500,
+		"message":"unrelated error code"}`,
+		false,
+		"unrelated",
+	}, {fmt.Sprintf(`{
+		"code" : -43106,
+		"message" : "%s"}`, customErrors.MissingBlocks()),
+		true,
+		"custom chain with error specified in toml config",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.network, func(t *testing.T) {
+			jsonRPCErr := evmclient.JsonError{}
+			err := json.Unmarshal([]byte(test.message), &jsonRPCErr)
+			if err == nil {
+				err = jsonRPCErr
+			}
+			assert.Equal(t, test.expect, evmclient.IsMissingBlocks(err, &customErrors), err)
+		})
+	}
 }

--- a/pkg/client/helpers_test.go
+++ b/pkg/client/helpers_test.go
@@ -38,6 +38,7 @@ type TestClientErrors struct {
 	fatal                             string
 	serviceUnavailable                string
 	tooManyResults                    string
+	missingBlocks                     string
 }
 
 func NewTestClientErrors() TestClientErrors {
@@ -57,6 +58,7 @@ func NewTestClientErrors() TestClientErrors {
 		fatal:                             "client error fatal",
 		serviceUnavailable:                "client error service unavailable",
 		tooManyResults:                    "client error too many results",
+		missingBlocks:                     "client error missing blocks",
 	}
 }
 
@@ -82,7 +84,8 @@ func (c *TestClientErrors) L2Full() string                  { return c.l2Full }
 func (c *TestClientErrors) TransactionAlreadyMined() string { return c.transactionAlreadyMined }
 func (c *TestClientErrors) Fatal() string                   { return c.fatal }
 func (c *TestClientErrors) ServiceUnavailable() string      { return c.serviceUnavailable }
-func (c *TestClientErrors) TooManyResults() string          { return c.serviceUnavailable }
+func (c *TestClientErrors) TooManyResults() string          { return c.tooManyResults }
+func (c *TestClientErrors) MissingBlocks() string           { return c.missingBlocks }
 
 type TestNodePoolConfig struct {
 	NodePollFailureThreshold       uint32

--- a/pkg/config/chain_scoped_client_errors.go
+++ b/pkg/config/chain_scoped_client_errors.go
@@ -49,3 +49,4 @@ func (c *clientErrorsConfig) ServiceUnavailable() string {
 	return derefOrDefault(c.c.ServiceUnavailable)
 }
 func (c *clientErrorsConfig) TooManyResults() string { return derefOrDefault(c.c.TooManyResults) }
+func (c *clientErrorsConfig) MissingBlocks() string  { return derefOrDefault(c.c.MissingBlocks) }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,6 +100,7 @@ type ClientErrors interface {
 	Fatal() string
 	ServiceUnavailable() string
 	TooManyResults() string
+	MissingBlocks() string
 }
 
 type Transactions interface {

--- a/pkg/config/toml/config.go
+++ b/pkg/config/toml/config.go
@@ -992,6 +992,7 @@ type ClientErrors struct {
 	Fatal                             *string `toml:",omitempty"`
 	ServiceUnavailable                *string `toml:",omitempty"`
 	TooManyResults                    *string `toml:",omitempty"`
+	MissingBlocks                     *string `toml:",omitempty"`
 }
 
 func (r *ClientErrors) setFrom(f *ClientErrors) bool {
@@ -1039,6 +1040,9 @@ func (r *ClientErrors) setFrom(f *ClientErrors) bool {
 	}
 	if v := f.TooManyResults; v != nil {
 		r.TooManyResults = v
+	}
+	if v := f.MissingBlocks; v != nil {
+		r.MissingBlocks = v
 	}
 	return true
 }

--- a/pkg/config/toml/config_test.go
+++ b/pkg/config/toml/config_test.go
@@ -95,6 +95,7 @@ func TestDefaults_fieldsNotNil(t *testing.T) {
 		Fatal:                             ptr("fatal"),
 		ServiceUnavailable:                ptr("unavailable"),
 		TooManyResults:                    ptr("too-many"),
+		MissingBlocks:                     ptr("missing"),
 	}
 
 	configtest.AssertFieldsNotNil(t, unknown)
@@ -321,6 +322,7 @@ var fullConfig = EVMConfig{
 				Fatal:                             ptr[string]("(: |^)fatal"),
 				ServiceUnavailable:                ptr[string]("(: |^)service unavailable"),
 				TooManyResults:                    ptr[string]("(: |^)too many results"),
+				MissingBlocks:                     ptr[string]("(: |^)invalid block range"),
 			},
 		},
 		OCR: OCR{

--- a/pkg/config/toml/docs.toml
+++ b/pkg/config/toml/docs.toml
@@ -470,6 +470,8 @@ Fatal = '(: |^)fatal' # Example
 ServiceUnavailable = '(: |^)service unavailable' # Example
 # TooManyResults is a regex pattern to match an eth_getLogs error indicating the result set is too large to return
 TooManyResults = '(: |^)too many results' # Example
+# MissingBlocks is a regex pattern to match an eth_getLogs error indicating the rpc server is permanently missing some blocks in the requested block range
+MissingBlocks = '(: |^)invalid block range'
 
 [OCR]
 # ContractConfirmations sets `OCR.ContractConfirmations` for this EVM chain.

--- a/pkg/config/toml/testdata/config-full.toml
+++ b/pkg/config/toml/testdata/config-full.toml
@@ -134,6 +134,7 @@ TransactionAlreadyMined = '(: |^)transaction already mined'
 Fatal = '(: |^)fatal'
 ServiceUnavailable = '(: |^)service unavailable'
 TooManyResults = '(: |^)too many results'
+MissingBlocks = '(: |^)invalid block range'
 
 [OCR]
 ContractConfirmations = 11

--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -137,6 +137,7 @@ type logPoller struct {
 	// LogPoller keeps running in infinite loop, so whenever the invalid state is removed from the database it should
 	// recover automatically without needing to restart the LogPoller.
 	finalityViolated           atomic.Bool
+	missingBlocksErrorCount    atomic.Uint64
 	countBasedLogPruningActive atomic.Bool
 }
 
@@ -536,6 +537,9 @@ func (lp *logPoller) Healthy() error {
 	if lp.finalityViolated.Load() {
 		return commontypes.ErrFinalityViolated
 	}
+	if errCount := lp.missingBlocksErrorCount.Load(); errCount > 2 {
+		return pkgerrors.Errorf("rpc servers reported missing blocks %d times in a row", errCount)
+	}
 	return nil
 }
 
@@ -901,6 +905,16 @@ func (lp *logPoller) backfill(ctx context.Context, start, end int64) error {
 
 		gethLogs, err := lp.latencyMonitor.FilterLogs(ctx, lp.Filter(big.NewInt(from), big.NewInt(to), nil))
 		if err != nil {
+			if client.IsMissingBlocks(err, lp.clientErrors) {
+				errCount := lp.missingBlocksErrorCount.Add(1)
+				if errCount < 2 {
+					lp.lggr.Errorw("Missing blocks", "err", err, "from", from, "to", to)
+					return err
+				}
+				lp.lggr.Criticalw("Missing blocks: cannot continue until at least one rpc server we're connected to has the logs for these blocks", "err", err, "from", from, "to", to)
+				lp.SvcErrBuffer.Append(err)
+				return err
+			}
 			if !client.IsTooManyResults(err, lp.clientErrors) {
 				lp.lggr.Errorw("Unable to query for logs", "err", err, "from", from, "to", to)
 				return err
@@ -915,6 +929,7 @@ func (lp *logPoller) backfill(ctx context.Context, start, end int64) error {
 			from -= batchSize // counteract +=batchSize on next loop iteration, so starting block does not change
 			continue
 		}
+		lp.missingBlocksErrorCount.Store(0) // clear unhealthy node state in case we were missing blocks and just found them
 		if len(gethLogs) == 0 {
 			continue
 		}


### PR DESCRIPTION
JIRA: [PLEX-1453](https://smartcontract-it.atlassian.net/browse/PLEX-1453)

#Description 

The specific error on hyperliquid we need to handle is "invalid block range", but the general error condition it represents is a state where the rpc server is permanently missing one or more blocks requested in an eth_getLogs range request.

This is required for hyperliquid, but could also be useful for any rpc server which prunes logs or blocks. If they've been permanently pruned, we want to continue. Adding for hyperlqiuid now, but making it configurable will make it easy to add support for any other chains we see this issue come up on.  Both immediately for the short term (via a custom toml config regex) and for the longer term by adding another regex to this `MissingBlocks` error & appropriate error code.

[PLEX-1453]: https://smartcontract-it.atlassian.net/browse/PLEX-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ