### PR TITLE
Add LogPoller Test ORM

### DIFF
--- a/pkg/logpoller/testing/test_orm.go
+++ b/pkg/logpoller/testing/test_orm.go
@@ -4,17 +4,18 @@ import (
 	"context"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 )
 
 type TestDSORM struct {
-	ds      sqlutil.DataSource
+	ds sqlutil.DataSource
 }
 
 // NewTestORM creates a test DSORM which contains method only used by tests
 func NewTestORM(ds sqlutil.DataSource) *TestDSORM {
 	return &TestDSORM{
-		ds:      ds,
+		ds: ds,
 	}
 }
 

--- a/pkg/logpoller/testing/test_orm.go
+++ b/pkg/logpoller/testing/test_orm.go
@@ -1,0 +1,32 @@
+package testing
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+)
+
+type TestDSORM struct {
+	ds      sqlutil.DataSource
+}
+
+// NewTestORM creates a test DSORM which contains method only used by tests
+func NewTestORM(ds sqlutil.DataSource) *TestDSORM {
+	return &TestDSORM{
+		ds:      ds,
+	}
+}
+
+// HasFilterByEventSig checks if a filter exists for the provided event sig
+func (o *TestDSORM) HasFilterByEventSig(ctx context.Context, chainID string, eventSig common.Hash) (bool, error) {
+	query := `SELECT COUNT(1) FROM evm.log_poller_filters
+		WHERE evm_chain_id = $1 AND event = $2 LIMIT 1`
+
+	var exists int
+	if err := o.ds.GetContext(ctx, &exists, query, chainID, eventSig.Bytes()); err != nil {
+		return false, err
+	}
+
+	return exists != 0, nil
+}

--- a/pkg/logpoller/testing/test_orm.go
+++ b/pkg/logpoller/testing/test_orm.go
@@ -20,12 +20,12 @@ func NewTestORM(ds sqlutil.DataSource) *TestDSORM {
 }
 
 // HasFilterByEventSig checks if a filter exists for the provided event sig and contract address
-func (o *TestDSORM) HasFilterByEventSig(ctx context.Context, chainID string, eventSig common.Hash, address common.Address) (bool, error) {
+func (o *TestDSORM) HasFilterByEventSig(ctx context.Context, chainID string, eventSig common.Hash, address []byte) (bool, error) {
 	query := `SELECT COUNT(1) FROM evm.log_poller_filters
 		WHERE evm_chain_id = $1 AND event = $2 AND address = $3 LIMIT 1`
 
 	var exists int
-	if err := o.ds.GetContext(ctx, &exists, query, chainID, eventSig.Bytes(), address.Bytes()); err != nil {
+	if err := o.ds.GetContext(ctx, &exists, query, chainID, eventSig.Bytes(), address); err != nil {
 		return false, err
 	}
 

--- a/pkg/logpoller/testing/test_orm.go
+++ b/pkg/logpoller/testing/test_orm.go
@@ -19,13 +19,13 @@ func NewTestORM(ds sqlutil.DataSource) *TestDSORM {
 	}
 }
 
-// HasFilterByEventSig checks if a filter exists for the provided event sig
-func (o *TestDSORM) HasFilterByEventSig(ctx context.Context, chainID string, eventSig common.Hash) (bool, error) {
+// HasFilterByEventSig checks if a filter exists for the provided event sig and contract address
+func (o *TestDSORM) HasFilterByEventSig(ctx context.Context, chainID string, eventSig common.Hash, address common.Address) (bool, error) {
 	query := `SELECT COUNT(1) FROM evm.log_poller_filters
-		WHERE evm_chain_id = $1 AND event = $2 LIMIT 1`
+		WHERE evm_chain_id = $1 AND event = $2 AND address = $3 LIMIT 1`
 
 	var exists int
-	if err := o.ds.GetContext(ctx, &exists, query, chainID, eventSig.Bytes()); err != nil {
+	if err := o.ds.GetContext(ctx, &exists, query, chainID, eventSig.Bytes(), address.Bytes()); err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
Created a test ORM for methods only needed by tests. The Solana CCIP E2E test needs to read the LogPoller DB to determine when filters for certain events are registered before proceeding

Core PR: https://github.com/smartcontractkit/chainlink/pull/17939