### PR TITLE
pkg/chains/legacyevm: reduce LegacyChains to ChainService

### DIFF
--- a/pkg/chains/legacyevm/chain.go
+++ b/pkg/chains/legacyevm/chain.go
@@ -64,22 +64,24 @@ var (
 
 // LegacyChains implements [LegacyChainContainer]
 type LegacyChains struct {
-	*chains.ChainsKV[Chain]
+	*chains.ChainsKV[types.ChainService]
 }
 
-// LegacyChainContainer is container for EVM chains.
+// LegacyChainContainer is container for EVM chains of type [types.ChainService], which may be castable to [Chain].
+// The cast will fail if the chain is running in LOOPP mode, in which case the legacy API is limited to the overlapping set
+// defined by [types.ChainService].
 type LegacyChainContainer interface {
-	Get(id string) (Chain, error)
+	Get(id string) (types.ChainService, error)
 	Len() int
-	List(ids ...string) ([]Chain, error)
-	Slice() []Chain
+	List(ids ...string) ([]types.ChainService, error)
+	Slice() []types.ChainService
 }
 
 var _ LegacyChainContainer = &LegacyChains{}
 
-func NewLegacyChains(m map[string]Chain) *LegacyChains {
+func NewLegacyChains(m map[string]types.ChainService) *LegacyChains {
 	return &LegacyChains{
-		ChainsKV: chains.NewChainsKV[Chain](m),
+		ChainsKV: chains.NewChainsKV[types.ChainService](m),
 	}
 }
 
@@ -88,7 +90,7 @@ func NewLegacyChains(m map[string]Chain) *LegacyChains {
 // *big.Int, string, and int64.
 //
 // TODO BCF-2507 unify the type system
-func (c *LegacyChains) Get(id string) (Chain, error) {
+func (c *LegacyChains) Get(id string) (types.ChainService, error) {
 	if id == nilBigInt.String() || id == emptyString {
 		return nil, fmt.Errorf("invalid chain id requested: %q", id)
 	}

--- a/pkg/chains/legacyevm/chain_test.go
+++ b/pkg/chains/legacyevm/chain_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/sqltest"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm/mocks"
@@ -17,7 +18,7 @@ import (
 func TestLegacyChains(t *testing.T) {
 	c := mocks.NewChain(t)
 	c.On("ID").Return(big.NewInt(7))
-	m := map[string]legacyevm.Chain{c.ID().String(): c}
+	m := map[string]types.ChainService{c.ID().String(): c}
 
 	l := legacyevm.NewLegacyChains(m)
 	got, err := l.Get(c.ID().String())


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CRE-192

`ChainService` is common to both `Chain` and `Relayer`. This changes reduces the legacy data structure to hold `ChainService`, so that we can include relayers instead of leaving them nil. Callers are then able to attempt a cast to `Chain` if necessary for their use case.

Supports:
- https://github.com/smartcontractkit/chainlink/pull/16578