### PR TITLE
PLEX-1486: Ensure endblock of each batch during a backfill is always written to mark progress

### DIFF
--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -937,7 +937,7 @@ func (lp *logPoller) backfill(ctx context.Context, start, end int64) error {
 		}
 
 		endblock := blocks[len(blocks)-1]
-		if len(gethLogs) == 0 || gethLogs[len(gethLogs)-1].BlockNumber != uint64(to) {
+		if len(gethLogs) == 0 || gethLogs[len(gethLogs)-1].BlockNumber != uint64(to) { //nolint:gosec // G115
 			// Pop endblock if there were no logs for it, so that length of blocks & gethLogs are the same to pass to convertLogs
 			blocks = blocks[:len(blocks)-1]
 		}
@@ -1206,7 +1206,13 @@ func (lp *logPoller) PruneOldBlocks(ctx context.Context) (bool, error) {
 		// No blocks saved yet.
 		return true, nil
 	}
-	if latestBlock.FinalizedBlockNumber <= lp.keepFinalizedBlocksDepth {
+
+	// If the latest block we have in the db was saved during a backfill, then the latest finalized
+	// block number stored with it will be larger than its block number. Instead of risking deleting
+	// all blocks from the db, we should still keep the latest keepFinalizedBlocksDepth blocks
+	referenceBlockNumber := mathutil.Min(latestBlock.FinalizedBlockNumber, latestBlock.BlockNumber)
+
+	if referenceBlockNumber <= lp.keepFinalizedBlocksDepth {
 		// No-op, keep all blocks
 		return true, nil
 	}

--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -930,9 +930,7 @@ func (lp *logPoller) backfill(ctx context.Context, start, end int64) error {
 			continue
 		}
 		lp.missingBlocksErrorCount.Store(0) // clear unhealthy node state in case we were missing blocks and just found them
-		if len(gethLogs) == 0 {
-			continue
-		}
+
 		blocks, err := lp.blocksFromFinalizedLogs(ctx, gethLogs, uint64(to)) //nolint:gosec // G115
 		if err != nil {
 			return err
@@ -944,7 +942,7 @@ func (lp *logPoller) backfill(ctx context.Context, start, end int64) error {
 			blocks = blocks[:len(blocks)-1]
 		}
 
-		lp.lggr.Debugw("Backfill found logs", "from", from, "to", to, "logs", len(gethLogs), "blocks", blocks)
+		lp.lggr.Debugw("Inserting backfilled logs with batch endblock", "from", from, "to", to, "logs", len(gethLogs), "blocks", blocks)
 		err = lp.orm.InsertLogsWithBlock(ctx, convertLogs(gethLogs, blocks, lp.lggr, lp.ec.ConfiguredChainID()), endblock)
 		if err != nil {
 			lp.lggr.Warnw("Unable to insert logs, retrying", "err", err, "from", from, "to", to)

--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -879,7 +879,7 @@ func (lp *logPoller) blocksFromFinalizedLogs(ctx context.Context, logs []types.L
 	for _, log := range logs {
 		numbers = append(numbers, log.BlockNumber)
 	}
-	if numbers[len(numbers)-1] != endBlockNumber {
+	if len(numbers) == 0 || numbers[len(numbers)-1] != endBlockNumber {
 		numbers = append(numbers, endBlockNumber)
 	}
 	blocks, err = lp.GetBlocksRange(ctx, numbers)
@@ -937,7 +937,7 @@ func (lp *logPoller) backfill(ctx context.Context, start, end int64) error {
 		}
 
 		endblock := blocks[len(blocks)-1]
-		if gethLogs[len(gethLogs)-1].BlockNumber != uint64(to) {
+		if len(gethLogs) == 0 || gethLogs[len(gethLogs)-1].BlockNumber != uint64(to) {
 			// Pop endblock if there were no logs for it, so that length of blocks & gethLogs are the same to pass to convertLogs
 			blocks = blocks[:len(blocks)-1]
 		}

--- a/pkg/logpoller/log_poller_test.go
+++ b/pkg/logpoller/log_poller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
@@ -1562,14 +1563,41 @@ func TestTooManyLogResults(t *testing.T) {
 		if blockNumber == nil {
 			require.FailNow(t, "unexpected call to get current head")
 		}
-		return &evmtypes.Head{Number: blockNumber.Int64()}, nil
+		return &evmtypes.Head{Number: blockNumber.Int64(), ParentHash: common.HexToHash(fmt.Sprintf("0x%x", blockNumber.Int64()-1))}, nil
 	})
 
 	t.Run("halves size until small enough, then succeeds", func(t *testing.T) {
-		// Simulate currentBlock = 300
+		// Simulate latestBlock = 300
 		head.Number = 300
+		head.Hash = common.HexToHash("0x1234") // needed to satisfy validation in fetchBlocks()
 		finalized.Number = head.Number - lpOpts.FinalityDepth
+
 		headTracker.On("LatestAndFinalizedBlock", mock.Anything).Return(head, finalized, nil).Once()
+
+		headByHash := ec.On("HeadByHash", mock.Anything, mock.Anything).Return(func(ctx context.Context, blockHash common.Hash) (*evmtypes.Head, error) {
+			return &evmtypes.Head{Hash: blockHash}, nil
+		})
+
+		batchCallContext := ec.On("BatchCallContext", mock.Anything, mock.Anything).Return(
+			func(ctx context.Context, calls []rpc.BatchElem) error {
+				for i := range calls {
+					blockNumberHex := calls[i].Args[0].(string)
+					if blockNumberHex == "latest" {
+						calls[i].Result = head
+						continue
+					}
+					blockNumber, ok := new(big.Int).SetString(blockNumberHex[2:], 16)
+					require.True(t, ok, blockNumberHex)
+
+					calls[i].Result = &evmtypes.Head{
+						Number:     blockNumber.Int64(),
+						Hash:       common.HexToHash(fmt.Sprintf("0x%x", blockNumber.Int64())),
+						ParentHash: common.HexToHash(fmt.Sprintf("0x%x", blockNumber.Int64()-1)),
+					}
+				}
+				return nil
+			},
+		)
 
 		filterLogsCall = ec.On("FilterLogs", mock.Anything, mock.Anything).Return(func(ctx context.Context, fq ethereum.FilterQuery) (logs []types.Log, err error) {
 			if fq.BlockHash != nil {
@@ -1605,6 +1633,8 @@ func TestTooManyLogResults(t *testing.T) {
 			assert.Equal(t, s, logs[i].ContextMap()["newBatchSize"])
 		}
 		filterLogsCall.Unset()
+		batchCallContext.Unset()
+		headByHash.Unset()
 	})
 
 	t.Run("Halves size until single block, then reports critical error", func(t *testing.T) {


### PR DESCRIPTION
Without this, a single error can cause any progress in searching through blocks fetched from an rpc server to get reset back to the beginning.