### PR TITLE
Correction to PR #93

### DIFF
--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -1220,7 +1220,7 @@ func (lp *logPoller) PruneOldBlocks(ctx context.Context) (bool, error) {
 	// Remove <= 2
 	rowsRemoved, err := lp.orm.DeleteBlocksBefore(
 		ctx,
-		latestBlock.FinalizedBlockNumber-lp.keepFinalizedBlocksDepth,
+		referenceBlockNumber-lp.keepFinalizedBlocksDepth,
 		lp.logPrunePageSize,
 	)
 	return lp.logPrunePageSize == 0 || rowsRemoved < lp.logPrunePageSize, err


### PR DESCRIPTION
This was an important part of the block pruning fix I'd intended to make in PR #93, somehow it got left out. 

The other line where referenceBlock is used is irrelevant for production environments, it's only for tests where blockchains can be shorter than the finality depth.  This is the one that matters for production.