### PR TITLE
pkg/chains: rm unused LegacyChainContainer.ChainNodeConfig

### DIFF
--- a/pkg/chains/legacyevm/chain.go
+++ b/pkg/chains/legacyevm/chain.go
@@ -31,7 +31,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller"
 	"github.com/smartcontractkit/chainlink-evm/pkg/monitor"
 	"github.com/smartcontractkit/chainlink-evm/pkg/txmgr"
-	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	ubig "github.com/smartcontractkit/chainlink-evm/pkg/utils/big"
 	trontxm "github.com/smartcontractkit/chainlink-tron/relayer/txm"
 )
@@ -66,8 +65,6 @@ var (
 // LegacyChains implements [LegacyChainContainer]
 type LegacyChains struct {
 	*chains.ChainsKV[Chain]
-
-	cfgs toml.EVMConfigs
 }
 
 // LegacyChainContainer is container for EVM chains.
@@ -76,24 +73,14 @@ type LegacyChainContainer interface {
 	Len() int
 	List(ids ...string) ([]Chain, error)
 	Slice() []Chain
-
-	// BCF-2516: this is only used for EVMORM. When we delete that
-	// we can promote/move the needed funcs from it to LegacyChainContainer
-	// so instead of EVMORM().XYZ() we'd have something like legacyChains.XYZ()
-	ChainNodeConfigs() evmtypes.Configs
 }
 
 var _ LegacyChainContainer = &LegacyChains{}
 
-func NewLegacyChains(m map[string]Chain, evmCfgs toml.EVMConfigs) *LegacyChains {
+func NewLegacyChains(m map[string]Chain) *LegacyChains {
 	return &LegacyChains{
 		ChainsKV: chains.NewChainsKV[Chain](m),
-		cfgs:     evmCfgs,
 	}
-}
-
-func (c *LegacyChains) ChainNodeConfigs() evmtypes.Configs {
-	return c.cfgs
 }
 
 // backward compatibility.

--- a/pkg/chains/legacyevm/chain.go
+++ b/pkg/chains/legacyevm/chain.go
@@ -64,22 +64,24 @@ var (
 
 // LegacyChains implements [LegacyChainContainer]
 type LegacyChains struct {
-	*chains.ChainsKV[Chain]
+	*chains.ChainsKV[types.ChainService]
 }
 
-// LegacyChainContainer is container for EVM chains.
+// LegacyChainContainer is container for EVM chains of type [types.ChainService], which may be castable to [Chain].
+// The cast will fail if the chain is running in LOOPP mode, in which case the legacy API is limited to the overlapping set
+// defined by [types.ChainService].
 type LegacyChainContainer interface {
-	Get(id string) (Chain, error)
+	Get(id string) (types.ChainService, error)
 	Len() int
-	List(ids ...string) ([]Chain, error)
-	Slice() []Chain
+	List(ids ...string) ([]types.ChainService, error)
+	Slice() []types.ChainService
 }
 
 var _ LegacyChainContainer = &LegacyChains{}
 
-func NewLegacyChains(m map[string]Chain) *LegacyChains {
+func NewLegacyChains(m map[string]types.ChainService) *LegacyChains {
 	return &LegacyChains{
-		ChainsKV: chains.NewChainsKV[Chain](m),
+		ChainsKV: chains.NewChainsKV[types.ChainService](m),
 	}
 }
 
@@ -88,7 +90,7 @@ func NewLegacyChains(m map[string]Chain) *LegacyChains {
 // *big.Int, string, and int64.
 //
 // TODO BCF-2507 unify the type system
-func (c *LegacyChains) Get(id string) (Chain, error) {
+func (c *LegacyChains) Get(id string) (types.ChainService, error) {
 	if id == nilBigInt.String() || id == emptyString {
 		return nil, fmt.Errorf("invalid chain id requested: %q", id)
 	}

--- a/pkg/chains/legacyevm/chain_test.go
+++ b/pkg/chains/legacyevm/chain_test.go
@@ -19,8 +19,7 @@ func TestLegacyChains(t *testing.T) {
 	c.On("ID").Return(big.NewInt(7))
 	m := map[string]legacyevm.Chain{c.ID().String(): c}
 
-	l := legacyevm.NewLegacyChains(m, []*toml.EVMConfig{})
-	assert.NotNil(t, l.ChainNodeConfigs())
+	l := legacyevm.NewLegacyChains(m)
 	got, err := l.Get(c.ID().String())
 	assert.NoError(t, err)
 	assert.Equal(t, c, got)

--- a/pkg/chains/legacyevm/chain_test.go
+++ b/pkg/chains/legacyevm/chain_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/sqltest"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm/mocks"
@@ -17,7 +18,7 @@ import (
 func TestLegacyChains(t *testing.T) {
 	c := mocks.NewChain(t)
 	c.On("ID").Return(big.NewInt(7))
-	m := map[string]legacyevm.Chain{c.ID().String(): c}
+	m := map[string]types.ChainService{c.ID().String(): c}
 
 	l := legacyevm.NewLegacyChains(m)
 	got, err := l.Get(c.ID().String())


### PR DESCRIPTION
Restore the reverted PRs #90 & #92. Don't merge until core side is ready.

Supports:
- https://github.com/smartcontractkit/chainlink/pull/16578