### PR TITLE
fix missing data-feeds compile in CI

### DIFF
--- a/gethwrappers/data-feeds/generation/generated-wrapper-dependency-versions-do-not-edit.txt
+++ b/gethwrappers/data-feeds/generation/generated-wrapper-dependency-versions-do-not-edit.txt
@@ -1,3 +1,3 @@
 GETH_VERSION: 1.15.3
-bundle_aggregator_proxy: ../../../contracts/solc/data-feeds/BundleAggregatorProxy/BundleAggregatorProxy.sol/BundleAggregatorProxy.abi.json ../../../contracts/solc/data-feeds/BundleAggregatorProxy/BundleAggregatorProxy.sol/BundleAggregatorProxy.bin b28fb697d1d846523f4552143dc7fb162054d3d387d110c02500203b7cd08b7c
-data_feeds_cache: ../../../contracts/solc/data-feeds/DataFeedsCache/DataFeedsCache.sol/DataFeedsCache.abi.json ../../../contracts/solc/data-feeds/DataFeedsCache/DataFeedsCache.sol/DataFeedsCache.bin dc334adf5274f87e5c05e5e6e794b22b1e313d6e8fda18e33699ab07e993cc27
+bundle_aggregator_proxy: ../../contracts/solc/data-feeds/BundleAggregatorProxy/BundleAggregatorProxy.sol/BundleAggregatorProxy.abi.json ../../contracts/solc/data-feeds/BundleAggregatorProxy/BundleAggregatorProxy.sol/BundleAggregatorProxy.bin b28fb697d1d846523f4552143dc7fb162054d3d387d110c02500203b7cd08b7c
+data_feeds_cache: ../../contracts/solc/data-feeds/DataFeedsCache/DataFeedsCache.sol/DataFeedsCache.abi.json ../../contracts/solc/data-feeds/DataFeedsCache/DataFeedsCache.sol/DataFeedsCache.bin dc334adf5274f87e5c05e5e6e794b22b1e313d6e8fda18e33699ab07e993cc27

--- a/gethwrappers/go_generate.go
+++ b/gethwrappers/go_generate.go
@@ -10,9 +10,11 @@ package gethwrappers
 
 //go:generate go generate go_generate_automation.go
 //go:generate go generate go_generate_vrf.go
+
 //go:generate go generate ./functions
 //go:generate go generate ./keystone
 //go:generate go generate ./llo-feeds
 //go:generate go generate ./operatorforwarder
 //go:generate go generate ./shared
 //go:generate go generate ./workflow
+//go:generate go generate ./data-feeds


### PR DESCRIPTION
Data feeds wasn't properly included in the main compile runner which made CI skip it