### PR TITLE
Insert and Trim in Batches for HeadTracker ORM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.62-0.20250630182638-8bd9c28cf772
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250704140446-cdafb991802c
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502
-	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250709154907-6a5bfa07ae87
+	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250710121035-c2447181731f
 	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20250618135814-7e3f79ab707e
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.62-0.20250630182638-8bd9c28cf772
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250704140446-cdafb991802c
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502
-	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250627121608-e7b52913fae2
+	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250709154907-6a5bfa07ae87
 	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20250618135814-7e3f79ab707e
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -644,8 +644,8 @@ github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250702175503-91
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250702175503-91331140edc3/go.mod h1:QUEPHdSkH19Or+E1iMGG+rDQ6jpCTIbm//9Osa6MXDE=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 h1:WLgEB8/lIfA1vI+7O4RE/PYitO57TRkKUqVllDIgJD4=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502/go.mod h1:Kb8f+wt2YmBdD0PfbsC9bDhdUG/Y8sqUkzAvC2Dn8/M=
-github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250709154907-6a5bfa07ae87 h1:Lf1dkt56wJcP5Nyja2vwSc2DWDcY6OFHLDzJ/Rz07fc=
-github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250709154907-6a5bfa07ae87/go.mod h1:+pRGfDej1r7cHMs1dYmuyPuOZzYB9Q+PKu0FvZOYlmw=
+github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250710121035-c2447181731f h1:BGGy7L2ArcPWFicgjpgOuv3sBBcVKILlDxHsWS1gZQ0=
+github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250710121035-c2447181731f/go.mod h1:+pRGfDej1r7cHMs1dYmuyPuOZzYB9Q+PKu0FvZOYlmw=
 github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20250618135814-7e3f79ab707e h1:LRT+PltY99+hxZAJn+4nyTfqGVNEM1S6FJ675B9BtJo=
 github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20250618135814-7e3f79ab707e/go.mod h1:jo+cUqNcHwN8IF7SInQNXDZ8qzBsyMpnLdYbDswviFc=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a h1:O28vgyHM7QF1YLg1BwkQSIbOYA+t0RiH9+b+k90GPG8=

--- a/go.sum
+++ b/go.sum
@@ -644,8 +644,8 @@ github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250702175503-91
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250702175503-91331140edc3/go.mod h1:QUEPHdSkH19Or+E1iMGG+rDQ6jpCTIbm//9Osa6MXDE=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502 h1:WLgEB8/lIfA1vI+7O4RE/PYitO57TRkKUqVllDIgJD4=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250618164021-9b34289a9502/go.mod h1:Kb8f+wt2YmBdD0PfbsC9bDhdUG/Y8sqUkzAvC2Dn8/M=
-github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250627121608-e7b52913fae2 h1:WRwVcv2IW59subaJDNl6B+N4OkZiAO7U2e9001XSw7c=
-github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250627121608-e7b52913fae2/go.mod h1:+pRGfDej1r7cHMs1dYmuyPuOZzYB9Q+PKu0FvZOYlmw=
+github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250709154907-6a5bfa07ae87 h1:Lf1dkt56wJcP5Nyja2vwSc2DWDcY6OFHLDzJ/Rz07fc=
+github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20250709154907-6a5bfa07ae87/go.mod h1:+pRGfDej1r7cHMs1dYmuyPuOZzYB9Q+PKu0FvZOYlmw=
 github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20250618135814-7e3f79ab707e h1:LRT+PltY99+hxZAJn+4nyTfqGVNEM1S6FJ675B9BtJo=
 github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20250618135814-7e3f79ab707e/go.mod h1:jo+cUqNcHwN8IF7SInQNXDZ8qzBsyMpnLdYbDswviFc=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20250522110034-65c54665034a h1:O28vgyHM7QF1YLg1BwkQSIbOYA+t0RiH9+b+k90GPG8=

--- a/pkg/chains/legacyevm/chain.go
+++ b/pkg/chains/legacyevm/chain.go
@@ -220,7 +220,7 @@ func newChain(cfg *config.ChainScoped, nodes []*toml.Node, opts ChainRelayOpts, 
 	} else if opts.GenHeadTracker == nil {
 		var orm heads.ORM
 		if cfg.EVM().HeadTracker().PersistenceEnabled() {
-			orm = heads.NewORM(*chainID, opts.DS)
+			orm = heads.NewORM(*chainID, opts.DS, cfg.EVM().HeadTracker().PersistenceBatchSize())
 		} else {
 			orm = heads.NewNullORM()
 		}

--- a/pkg/config/chain_scoped_head_tracker.go
+++ b/pkg/config/chain_scoped_head_tracker.go
@@ -33,3 +33,7 @@ func (h *headTrackerConfig) MaxAllowedFinalityDepth() uint32 {
 func (h *headTrackerConfig) PersistenceEnabled() bool {
 	return *h.c.PersistenceEnabled
 }
+
+func (h *headTrackerConfig) PersistenceBatchSize() int64 {
+	return *h.c.PersistenceBatchSize
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,7 @@ type HeadTracker interface {
 	FinalityTagBypass() bool
 	MaxAllowedFinalityDepth() uint32
 	PersistenceEnabled() bool
+	PersistenceBatchSize() int64
 }
 
 type BalanceMonitor interface {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -356,6 +356,7 @@ func TestChainScopedConfig_HeadTracker(t *testing.T) {
 	assert.False(t, ht.FinalityTagBypass())
 	assert.Equal(t, uint32(10000), ht.MaxAllowedFinalityDepth())
 	assert.True(t, ht.PersistenceEnabled())
+	assert.Equal(t, int64(100), ht.PersistenceBatchSize())
 }
 
 func TestNodePoolConfig(t *testing.T) {

--- a/pkg/config/toml/config.go
+++ b/pkg/config/toml/config.go
@@ -969,6 +969,7 @@ type HeadTracker struct {
 	MaxAllowedFinalityDepth *uint32
 	FinalityTagBypass       *bool
 	PersistenceEnabled      *bool
+	PersistenceBatchSize    *int64
 }
 
 func (t *HeadTracker) setFrom(f *HeadTracker) {
@@ -989,6 +990,9 @@ func (t *HeadTracker) setFrom(f *HeadTracker) {
 	}
 	if v := f.PersistenceEnabled; v != nil {
 		t.PersistenceEnabled = v
+	}
+	if v := f.PersistenceBatchSize; v != nil {
+		t.PersistenceBatchSize = v
 	}
 }
 

--- a/pkg/config/toml/config_test.go
+++ b/pkg/config/toml/config_test.go
@@ -301,6 +301,7 @@ var fullConfig = EVMConfig{
 			FinalityTagBypass:       ptr[bool](false),
 			MaxAllowedFinalityDepth: ptr[uint32](1500),
 			PersistenceEnabled:      ptr(false),
+			PersistenceBatchSize:    ptr[int64](100),
 		},
 
 		NodePool: NodePool{

--- a/pkg/config/toml/defaults/fallback.toml
+++ b/pkg/config/toml/defaults/fallback.toml
@@ -73,6 +73,7 @@ SamplingInterval = '1s'
 FinalityTagBypass = false
 MaxAllowedFinalityDepth = 10000
 PersistenceEnabled = true
+PersistenceBatchSize = 100
 
 [NodePool]
 PollFailureThreshold = 5

--- a/pkg/config/toml/docs.toml
+++ b/pkg/config/toml/docs.toml
@@ -389,6 +389,8 @@ MaxAllowedFinalityDepth = 10000 # Default
 # On chains with fast finality, the persistence layer does not improve the chain's load time and only consumes database resources (mainly IO).
 # NOTE: persistence should not be disabled for products that use LogBroadcaster, as it might lead to missed on-chain events.
 PersistenceEnabled = true # Default
+# Batch size for db inserts/deletes
+PersistenceBatchSize = 100 # Default
 
 [[KeySpecific]]
 # Key is the account to apply these settings to

--- a/pkg/config/toml/testdata/config-full.toml
+++ b/pkg/config/toml/testdata/config-full.toml
@@ -101,6 +101,7 @@ SamplingInterval = '1h0m0s'
 MaxAllowedFinalityDepth = 1500
 FinalityTagBypass = false
 PersistenceEnabled = false
+PersistenceBatchSize = 100
 
 [[KeySpecific]]
 Key = '0x2a3e23c6f242F5345320814aC8a1b4E58707D292'

--- a/pkg/heads/broadcaster_test.go
+++ b/pkg/heads/broadcaster_test.go
@@ -70,7 +70,7 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 	checker1 := &CountingHeadTrackable{}
 	checker2 := &CountingHeadTrackable{}
 
-	orm := evmheads.NewORM(*ethClient.ConfiguredChainID(), db, 1)
+	orm := evmheads.NewORM(*ethClient.ConfiguredChainID(), db, 0)
 	hs := evmheads.NewSaver(logger, orm, evmCfg.EVM(), evmCfg.EVM().HeadTracker())
 	mailMon := mailboxtest.NewMonitor(t)
 	servicetest.Run(t, mailMon)

--- a/pkg/heads/broadcaster_test.go
+++ b/pkg/heads/broadcaster_test.go
@@ -70,7 +70,7 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 	checker1 := &CountingHeadTrackable{}
 	checker2 := &CountingHeadTrackable{}
 
-	orm := evmheads.NewORM(*ethClient.ConfiguredChainID(), db)
+	orm := evmheads.NewORM(*ethClient.ConfiguredChainID(), db, 1)
 	hs := evmheads.NewSaver(logger, orm, evmCfg.EVM(), evmCfg.EVM().HeadTracker())
 	mailMon := mailboxtest.NewMonitor(t)
 	servicetest.Run(t, mailMon)

--- a/pkg/heads/orm.go
+++ b/pkg/heads/orm.go
@@ -36,10 +36,10 @@ var _ ORM = &DbORM{}
 type DbORM struct {
 	chainID                ubig.Big
 	ds                     sqlutil.DataSource
-	lastTrimmedBlockNumber int64
 	mu                     sync.RWMutex
-	batchSize              int64 // 0 works as no batching
-	headsBatch             []*evmtypes.Head
+	batchSize              int64            // 0 works as no batching
+	lastTrimmedBlockNumber int64            // used to trim in batches
+	headsBatch             []*evmtypes.Head // used to batch insert heads
 }
 
 // NewORM creates an ORM scoped to chainID.
@@ -60,9 +60,9 @@ func (orm *DbORM) batchInsertHeadsLocked(ctx context.Context, heads []*evmtypes.
 
 	var (
 		query = `
-INSERT INTO evm.heads 
-  (hash, number, parent_hash, created_at, timestamp, l1_block_number, evm_chain_id, base_fee_per_gas)
-VALUES `
+			INSERT INTO evm.heads 
+				(hash, number, parent_hash, created_at, timestamp, l1_block_number, evm_chain_id, base_fee_per_gas)
+			VALUES `
 		placeholders []string
 		args         []interface{}
 	)
@@ -84,7 +84,6 @@ VALUES `
 	}
 
 	query += strings.Join(placeholders, ",\n") + "\nON CONFLICT (evm_chain_id, hash) DO NOTHING"
-	fmt.Println(query)
 	_, err := orm.ds.ExecContext(ctx, query, args...)
 	return err
 }

--- a/pkg/heads/orm.go
+++ b/pkg/heads/orm.go
@@ -19,7 +19,7 @@ type ORM interface {
 	// No advisory lock required because this is thread safe.
 	IdempotentInsertHead(ctx context.Context, head *evmtypes.Head) error
 	// TrimOldHeads deletes heads such that only blocks >= minBlockNumber remain
-	TrimOldHeads(ctx context.Context, minBlockNumber int64) (err error)
+	TrimOldHeads(ctx context.Context, minBlockNumber int64, batchSize int64) (err error)
 	// LatestHead returns the highest seen head
 	LatestHead(ctx context.Context) (head *evmtypes.Head, err error)
 	// LatestHeads returns the latest heads with blockNumbers >= minBlockNumber
@@ -31,15 +31,17 @@ type ORM interface {
 var _ ORM = &DbORM{}
 
 type DbORM struct {
-	chainID ubig.Big
-	ds      sqlutil.DataSource
+	chainID                ubig.Big
+	ds                     sqlutil.DataSource
+	lastTrimmedBlockNumber int64
 }
 
 // NewORM creates an ORM scoped to chainID.
 func NewORM(chainID big.Int, ds sqlutil.DataSource) *DbORM {
 	return &DbORM{
-		chainID: ubig.Big(chainID),
-		ds:      ds,
+		chainID:                ubig.Big(chainID),
+		ds:                     ds,
+		lastTrimmedBlockNumber: -1,
 	}
 }
 
@@ -53,7 +55,14 @@ func (orm *DbORM) IdempotentInsertHead(ctx context.Context, head *evmtypes.Head)
 	return pkgerrors.Wrap(err, "IdempotentInsertHead failed to insert head")
 }
 
-func (orm *DbORM) TrimOldHeads(ctx context.Context, minBlockNumber int64) (err error) {
+func (orm *DbORM) TrimOldHeads(ctx context.Context, minBlockNumber int64, batchSize int64) (err error) {
+	if orm.lastTrimmedBlockNumber == -1 {
+		orm.lastTrimmedBlockNumber = minBlockNumber
+		return nil
+	} else if orm.lastTrimmedBlockNumber+batchSize > minBlockNumber {
+		return nil
+	}
+	orm.lastTrimmedBlockNumber = minBlockNumber
 	query := `DELETE FROM evm.heads WHERE evm_chain_id = $1 AND number < $2`
 	_, err = orm.ds.ExecContext(ctx, query, orm.chainID, minBlockNumber)
 	return err
@@ -94,7 +103,7 @@ func (orm *nullORM) IdempotentInsertHead(ctx context.Context, head *evmtypes.Hea
 	return nil
 }
 
-func (orm *nullORM) TrimOldHeads(ctx context.Context, minBlockNumber int64) (err error) {
+func (orm *nullORM) TrimOldHeads(ctx context.Context, minBlockNumber int64, batchSize int64) (err error) {
 	return nil
 }
 

--- a/pkg/heads/orm.go
+++ b/pkg/heads/orm.go
@@ -53,7 +53,7 @@ func NewORM(chainID big.Int, ds sqlutil.DataSource, batchSize int64) *DbORM {
 	}
 }
 
-func (orm *DbORM) batchInsertHeadsLocked(ctx context.Context, heads []*evmtypes.Head) error {
+func (orm *DbORM) batchInsertHeads(ctx context.Context, heads []*evmtypes.Head) error {
 	if len(heads) == 0 {
 		return nil
 	}
@@ -63,8 +63,8 @@ func (orm *DbORM) batchInsertHeadsLocked(ctx context.Context, heads []*evmtypes.
 			INSERT INTO evm.heads 
 				(hash, number, parent_hash, created_at, timestamp, l1_block_number, evm_chain_id, base_fee_per_gas)
 			VALUES `
-		placeholders []string
-		args         []interface{}
+		placeholders = make([]string, 0, len(heads))
+		args         = make([]interface{}, 0, len(heads)*7)
 	)
 
 	for i, head := range heads {
@@ -100,7 +100,7 @@ func (orm *DbORM) IdempotentInsertHead(ctx context.Context, head *evmtypes.Head)
 	}
 
 	// Batch insert
-	err := orm.batchInsertHeadsLocked(ctx, orm.headsBatch)
+	err := orm.batchInsertHeads(ctx, orm.headsBatch)
 	if err != nil {
 		return pkgerrors.Wrap(err, "IdempotentInsertHead failed to batch insert heads")
 	}

--- a/pkg/heads/orm.go
+++ b/pkg/heads/orm.go
@@ -3,10 +3,9 @@ package heads
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"math/big"
-	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	pkgerrors "github.com/pkg/errors"
@@ -57,35 +56,24 @@ func (orm *DbORM) batchInsertHeads(ctx context.Context, heads []*evmtypes.Head) 
 	if len(heads) == 0 {
 		return nil
 	}
-
-	var (
-		query = `
+	// explicitly set created_at to now()
+	// as now() does not work with batch inserts
+	createdAt := time.Now().UTC()
+	for _, head := range heads {
+		head.CreatedAt = createdAt
+	}
+	query := `
 			INSERT INTO evm.heads 
 				(hash, number, parent_hash, created_at, timestamp, l1_block_number, evm_chain_id, base_fee_per_gas)
-			VALUES `
-		placeholders = make([]string, 0, len(heads))
-		args         = make([]interface{}, 0, len(heads)*7)
-	)
+			VALUES (:hash, :number, :parent_hash, :created_at, :timestamp, :l1_block_number, :evm_chain_id, :base_fee_per_gas)
+				ON CONFLICT DO NOTHING`
 
-	for i, head := range heads {
-		offset := i * 7
-		placeholders = append(placeholders,
-			fmt.Sprintf("($%d, $%d, $%d, now(), $%d, $%d, $%d, $%d)",
-				offset+1, offset+2, offset+3, offset+4, offset+5, offset+6, offset+7))
-		args = append(args,
-			head.Hash,
-			head.Number,
-			head.ParentHash,
-			head.Timestamp,
-			head.L1BlockNumber,
-			orm.chainID,
-			head.BaseFeePerGas,
-		)
+	_, err := orm.ds.NamedExecContext(ctx, query, heads)
+	if err != nil {
+		return err
 	}
 
-	query += strings.Join(placeholders, ",\n") + "\nON CONFLICT (evm_chain_id, hash) DO NOTHING"
-	_, err := orm.ds.ExecContext(ctx, query, args...)
-	return err
+	return nil
 }
 
 func (orm *DbORM) IdempotentInsertHead(ctx context.Context, head *evmtypes.Head) error {

--- a/pkg/heads/orm.go
+++ b/pkg/heads/orm.go
@@ -3,7 +3,10 @@ package heads
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"math/big"
+	"strings"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	pkgerrors "github.com/pkg/errors"
@@ -19,7 +22,7 @@ type ORM interface {
 	// No advisory lock required because this is thread safe.
 	IdempotentInsertHead(ctx context.Context, head *evmtypes.Head) error
 	// TrimOldHeads deletes heads such that only blocks >= minBlockNumber remain
-	TrimOldHeads(ctx context.Context, minBlockNumber int64, batchSize int64) (err error)
+	TrimOldHeads(ctx context.Context, minBlockNumber int64) (err error)
 	// LatestHead returns the highest seen head
 	LatestHead(ctx context.Context) (head *evmtypes.Head, err error)
 	// LatestHeads returns the latest heads with blockNumbers >= minBlockNumber
@@ -34,32 +37,88 @@ type DbORM struct {
 	chainID                ubig.Big
 	ds                     sqlutil.DataSource
 	lastTrimmedBlockNumber int64
+	mu                     sync.RWMutex
+	batchSize              int64 // 0 works as no batching
+	headsBatch             []*evmtypes.Head
 }
 
 // NewORM creates an ORM scoped to chainID.
-func NewORM(chainID big.Int, ds sqlutil.DataSource) *DbORM {
+func NewORM(chainID big.Int, ds sqlutil.DataSource, batchSize int64) *DbORM {
 	return &DbORM{
 		chainID:                ubig.Big(chainID),
 		ds:                     ds,
 		lastTrimmedBlockNumber: -1,
+		batchSize:              batchSize,
+		headsBatch:             make([]*evmtypes.Head, 0, batchSize),
 	}
 }
 
-func (orm *DbORM) IdempotentInsertHead(ctx context.Context, head *evmtypes.Head) error {
-	// listener guarantees head.EVMChainID to be equal to DbORM.chainID
-	query := `
-	INSERT INTO evm.heads (hash, number, parent_hash, created_at, timestamp, l1_block_number, evm_chain_id, base_fee_per_gas) VALUES (
-	$1, $2, $3, now(), $4, $5, $6, $7)
-	ON CONFLICT (evm_chain_id, hash) DO NOTHING`
-	_, err := orm.ds.ExecContext(ctx, query, head.Hash, head.Number, head.ParentHash, head.Timestamp, head.L1BlockNumber, orm.chainID, head.BaseFeePerGas)
-	return pkgerrors.Wrap(err, "IdempotentInsertHead failed to insert head")
+func (orm *DbORM) batchInsertHeadsLocked(ctx context.Context, heads []*evmtypes.Head) error {
+	if len(heads) == 0 {
+		return nil
+	}
+
+	var (
+		query = `
+INSERT INTO evm.heads 
+  (hash, number, parent_hash, created_at, timestamp, l1_block_number, evm_chain_id, base_fee_per_gas)
+VALUES `
+		placeholders []string
+		args         []interface{}
+	)
+
+	for i, head := range heads {
+		offset := i * 7
+		placeholders = append(placeholders,
+			fmt.Sprintf("($%d, $%d, $%d, now(), $%d, $%d, $%d, $%d)",
+				offset+1, offset+2, offset+3, offset+4, offset+5, offset+6, offset+7))
+		args = append(args,
+			head.Hash,
+			head.Number,
+			head.ParentHash,
+			head.Timestamp,
+			head.L1BlockNumber,
+			orm.chainID,
+			head.BaseFeePerGas,
+		)
+	}
+
+	query += strings.Join(placeholders, ",\n") + "\nON CONFLICT (evm_chain_id, hash) DO NOTHING"
+	fmt.Println(query)
+	_, err := orm.ds.ExecContext(ctx, query, args...)
+	return err
 }
 
-func (orm *DbORM) TrimOldHeads(ctx context.Context, minBlockNumber int64, batchSize int64) (err error) {
+func (orm *DbORM) IdempotentInsertHead(ctx context.Context, head *evmtypes.Head) error {
+	orm.mu.Lock()
+	defer orm.mu.Unlock()
+
+	orm.headsBatch = append(orm.headsBatch, head)
+
+	if len(orm.headsBatch) < int(orm.batchSize) {
+		// Not enough to batch insert yet
+		return nil
+	}
+
+	// Batch insert
+	err := orm.batchInsertHeadsLocked(ctx, orm.headsBatch)
+	if err != nil {
+		return pkgerrors.Wrap(err, "IdempotentInsertHead failed to batch insert heads")
+	}
+
+	// Clear buffer
+	orm.headsBatch = orm.headsBatch[:0]
+	return nil
+}
+
+func (orm *DbORM) TrimOldHeads(ctx context.Context, minBlockNumber int64) (err error) {
+	orm.mu.Lock()
+	defer orm.mu.Unlock()
 	if orm.lastTrimmedBlockNumber == -1 {
 		orm.lastTrimmedBlockNumber = minBlockNumber
 		return nil
-	} else if orm.lastTrimmedBlockNumber+batchSize > minBlockNumber {
+	} else if orm.lastTrimmedBlockNumber+orm.batchSize > minBlockNumber {
+		// Batch not big enough to trim yet
 		return nil
 	}
 	orm.lastTrimmedBlockNumber = minBlockNumber
@@ -103,7 +162,7 @@ func (orm *nullORM) IdempotentInsertHead(ctx context.Context, head *evmtypes.Hea
 	return nil
 }
 
-func (orm *nullORM) TrimOldHeads(ctx context.Context, minBlockNumber int64, batchSize int64) (err error) {
+func (orm *nullORM) TrimOldHeads(ctx context.Context, minBlockNumber int64) (err error) {
 	return nil
 }
 

--- a/pkg/heads/orm.go
+++ b/pkg/heads/orm.go
@@ -115,8 +115,8 @@ func (orm *DbORM) TrimOldHeads(ctx context.Context, minBlockNumber int64) (err e
 	defer orm.mu.Unlock()
 	if orm.lastTrimmedBlockNumber == -1 {
 		orm.lastTrimmedBlockNumber = minBlockNumber
-		return nil
-	} else if orm.lastTrimmedBlockNumber+orm.batchSize > minBlockNumber {
+	}
+	if orm.lastTrimmedBlockNumber+orm.batchSize > minBlockNumber {
 		// Batch not big enough to trim yet
 		return nil
 	}

--- a/pkg/heads/orm_test.go
+++ b/pkg/heads/orm_test.go
@@ -17,7 +17,7 @@ func TestORM_IdempotentInsertHead(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	orm := heads.NewORM(*testutils.FixtureChainID, db)
+	orm := heads.NewORM(*testutils.FixtureChainID, db, 0)
 
 	// Returns nil when inserting first head
 	head := testutils.Head(0)
@@ -37,31 +37,56 @@ func TestORM_IdempotentInsertHead(t *testing.T) {
 	assert.Equal(t, head.Hash, foundHead.Hash)
 }
 
+func TestORM_IdempotentInsertHead_Batch(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.NewSqlxDB(t)
+	orm := heads.NewORM(*testutils.FixtureChainID, db, 2)
+
+	// Returns nil when inserting first head
+	head := testutils.Head(0)
+	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), head))
+
+	// But does not really insert head as batch size is 2
+	foundHead, err := orm.LatestHead(tests.Context(t))
+	require.NoError(t, err)
+	require.Nil(t, foundHead)
+
+	// Returns nil when inserting same head again
+	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), head))
+
+	// Inserts the head as batch size is 2
+	// But maintains dup check
+	heads, err := orm.LatestHeads(tests.Context(t), 0)
+	require.NoError(t, err)
+	require.Len(t, heads, 1)
+	assert.Equal(t, head.Hash, heads[0].Hash)
+}
+
 func TestORM_TrimOldHeads(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	orm := heads.NewORM(*testutils.FixtureChainID, db)
+	orm := heads.NewORM(*testutils.FixtureChainID, db, 2)
 
 	for i := 0; i < 10; i++ {
 		head := testutils.Head(i)
-		require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), head))
+		require.NoError(t, orm.IdempotentInsertHead(t.Context(), head))
 	}
 
 	uncleHead := testutils.Head(5)
-	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), uncleHead))
+	require.NoError(t, orm.IdempotentInsertHead(t.Context(), uncleHead))
 
-	batchSize := int64(2)
-	err := orm.TrimOldHeads(tests.Context(t), 5, batchSize)
+	err := orm.TrimOldHeads(t.Context(), 5)
 	require.NoError(t, err)
 
-	err = orm.TrimOldHeads(tests.Context(t), 6, batchSize)
+	err = orm.TrimOldHeads(t.Context(), 6)
 	require.NoError(t, err)
 
-	err = orm.TrimOldHeads(tests.Context(t), 7, batchSize)
+	err = orm.TrimOldHeads(t.Context(), 7)
 	require.NoError(t, err)
 
-	heads, err := orm.LatestHeads(tests.Context(t), 0)
+	heads, err := orm.LatestHeads(t.Context(), 0)
 	require.NoError(t, err)
 
 	// uncle block was loaded too
@@ -75,7 +100,7 @@ func TestORM_HeadByHash(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	orm := heads.NewORM(*testutils.FixtureChainID, db)
+	orm := heads.NewORM(*testutils.FixtureChainID, db, 0)
 
 	var hash common.Hash
 	for i := 0; i < 10; i++ {
@@ -96,7 +121,7 @@ func TestORM_HeadByHash_NotFound(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	orm := heads.NewORM(*testutils.FixtureChainID, db)
+	orm := heads.NewORM(*testutils.FixtureChainID, db, 0)
 
 	hash := testutils.Head(123).Hash
 	head, err := orm.HeadByHash(tests.Context(t), hash)
@@ -109,7 +134,7 @@ func TestORM_LatestHeads_NoRows(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
-	orm := heads.NewORM(*testutils.FixtureChainID, db)
+	orm := heads.NewORM(*testutils.FixtureChainID, db, 0)
 
 	heads, err := orm.LatestHeads(tests.Context(t), 100)
 

--- a/pkg/heads/orm_test.go
+++ b/pkg/heads/orm_test.go
@@ -51,13 +51,14 @@ func TestORM_TrimOldHeads(t *testing.T) {
 	uncleHead := testutils.Head(5)
 	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), uncleHead))
 
-	err := orm.TrimOldHeads(tests.Context(t), 5, 2)
+	batchSize := int64(2)
+	err := orm.TrimOldHeads(tests.Context(t), 5, batchSize)
 	require.NoError(t, err)
 
-	err = orm.TrimOldHeads(tests.Context(t), 6, 2)
+	err = orm.TrimOldHeads(tests.Context(t), 6, batchSize)
 	require.NoError(t, err)
 
-	err = orm.TrimOldHeads(tests.Context(t), 7, 2)
+	err = orm.TrimOldHeads(tests.Context(t), 7, batchSize)
 	require.NoError(t, err)
 
 	heads, err := orm.LatestHeads(tests.Context(t), 0)

--- a/pkg/heads/orm_test.go
+++ b/pkg/heads/orm_test.go
@@ -51,16 +51,22 @@ func TestORM_TrimOldHeads(t *testing.T) {
 	uncleHead := testutils.Head(5)
 	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), uncleHead))
 
-	err := orm.TrimOldHeads(tests.Context(t), 5)
+	err := orm.TrimOldHeads(tests.Context(t), 5, 0)
+	require.NoError(t, err)
+
+	err = orm.TrimOldHeads(tests.Context(t), 6, 2)
+	require.NoError(t, err)
+
+	err = orm.TrimOldHeads(tests.Context(t), 7, 2)
 	require.NoError(t, err)
 
 	heads, err := orm.LatestHeads(tests.Context(t), 0)
 	require.NoError(t, err)
 
 	// uncle block was loaded too
-	require.Len(t, heads, 6)
-	for i := 0; i < 5; i++ {
-		require.LessOrEqual(t, int64(5), heads[i].Number)
+	require.Len(t, heads, 3)
+	for i := 0; i < 3; i++ {
+		require.LessOrEqual(t, int64(7), heads[i].Number)
 	}
 }
 

--- a/pkg/heads/orm_test.go
+++ b/pkg/heads/orm_test.go
@@ -51,7 +51,7 @@ func TestORM_TrimOldHeads(t *testing.T) {
 	uncleHead := testutils.Head(5)
 	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), uncleHead))
 
-	err := orm.TrimOldHeads(tests.Context(t), 5, 0)
+	err := orm.TrimOldHeads(tests.Context(t), 5, 2)
 	require.NoError(t, err)
 
 	err = orm.TrimOldHeads(tests.Context(t), 6, 2)

--- a/pkg/heads/orm_test.go
+++ b/pkg/heads/orm_test.go
@@ -45,19 +45,19 @@ func TestORM_IdempotentInsertHead_Batch(t *testing.T) {
 
 	// Returns nil when inserting first head
 	head := testutils.Head(0)
-	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), head))
+	require.NoError(t, orm.IdempotentInsertHead(t.Context(), head))
 
 	// But does not really insert head as batch size is 2
-	foundHead, err := orm.LatestHead(tests.Context(t))
+	foundHead, err := orm.LatestHead(t.Context())
 	require.NoError(t, err)
 	require.Nil(t, foundHead)
 
 	// Returns nil when inserting same head again
-	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), head))
+	require.NoError(t, orm.IdempotentInsertHead(t.Context(), head))
 
-	// Inserts the head as batch size is 2
-	// But maintains dup check
-	heads, err := orm.LatestHeads(tests.Context(t), 0)
+	// Inserts the head as in memorybatch size is 2
+	// But maintains dup check and ends up with only one head
+	heads, err := orm.LatestHeads(t.Context(), 0)
 	require.NoError(t, err)
 	require.Len(t, heads, 1)
 	assert.Equal(t, head.Hash, heads[0].Hash)

--- a/pkg/heads/saver.go
+++ b/pkg/heads/saver.go
@@ -84,7 +84,7 @@ func (hs *saver) MarkFinalized(ctx context.Context, finalized *evmtypes.Head) er
 		return fmt.Errorf("failed to find %s block in the canonical chain to mark it as finalized", finalized)
 	}
 
-	return hs.orm.TrimOldHeads(ctx, minBlockToKeep)
+	return hs.orm.TrimOldHeads(ctx, minBlockToKeep, hs.htConfig.PersistenceBatchSize())
 }
 
 var NullSaver HeadSaver = &nullSaver{}

--- a/pkg/heads/saver.go
+++ b/pkg/heads/saver.go
@@ -84,7 +84,7 @@ func (hs *saver) MarkFinalized(ctx context.Context, finalized *evmtypes.Head) er
 		return fmt.Errorf("failed to find %s block in the canonical chain to mark it as finalized", finalized)
 	}
 
-	return hs.orm.TrimOldHeads(ctx, minBlockToKeep, hs.htConfig.PersistenceBatchSize())
+	return hs.orm.TrimOldHeads(ctx, minBlockToKeep)
 }
 
 var NullSaver HeadSaver = &nullSaver{}

--- a/pkg/heads/saver_test.go
+++ b/pkg/heads/saver_test.go
@@ -44,6 +44,9 @@ func (h *trackerConfig) MaxAllowedFinalityDepth() uint32 {
 func (h *trackerConfig) PersistenceEnabled() bool {
 	return true
 }
+func (h *trackerConfig) PersistenceBatchSize() int64 {
+	return 0
+}
 
 type config struct {
 	safeBlockDepth                    uint32

--- a/pkg/heads/saver_test.go
+++ b/pkg/heads/saver_test.go
@@ -81,7 +81,7 @@ func configureSaver(t *testing.T, opts saverOpts) (evmheads.HeadSaver, evmheads.
 	db := testutils.NewSqlxDB(t)
 	lggr := logger.Test(t)
 	htCfg := &config{finalityDepth: uint32(1)}
-	orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+	orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 	saver := evmheads.NewSaver(lggr, orm, htCfg, opts.headTrackerConfig)
 	return saver, orm
 }

--- a/pkg/heads/tracker_test.go
+++ b/pkg/heads/tracker_test.go
@@ -67,7 +67,7 @@ func TestHeadTracker_New(t *testing.T) {
 		Maybe().
 		Return(nil, mockEth.NewSub(t), nil)
 
-	orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+	orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), testutils.Head(1)))
 	last := testutils.Head(16)
 	require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), last))
@@ -92,7 +92,7 @@ func TestHeadTracker_MarkFinalized_MarksAndTrimsTable(t *testing.T) {
 	})
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
-	orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+	orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 
 	for idx := 0; idx < 200; idx++ {
 		require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), testutils.Head(idx)))
@@ -138,7 +138,7 @@ func TestHeadTracker_Get(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			db := testutils.NewSqlxDB(t)
 			config := configtest.NewChainScopedConfig(t, nil)
-			orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+			orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 
 			ethClient := clienttest.NewClientWithDefaultChainID(t)
 			chStarted := make(chan struct{})
@@ -186,7 +186,7 @@ func TestHeadTracker_Start_NewHeads(t *testing.T) {
 
 	db := testutils.NewSqlxDB(t)
 	config := configtest.NewChainScopedConfig(t, nil)
-	orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+	orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	chStarted := make(chan struct{})
@@ -217,7 +217,7 @@ func TestHeadTracker_NewHeads_FinalityViolations(t *testing.T) {
 		config := configtest.NewChainScopedConfig(t, func(c *toml.EVMConfig) {
 			c.FinalityTagEnabled = ptr(true)
 		})
-		orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+		orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 
 		ethClient := clienttest.NewClientWithDefaultChainID(t)
 		chStarted := make(chan struct{})
@@ -272,7 +272,7 @@ func TestHeadTracker_NewHeads_FinalityViolations(t *testing.T) {
 			// finalty violation on old block possible only with finalty tag
 			c.HeadTracker.FinalityTagBypass = ptr(true)
 		})
-		orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+		orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 
 		ethClient := clienttest.NewClientWithDefaultChainID(t)
 		chStarted := make(chan struct{})
@@ -330,7 +330,7 @@ func TestHeadTracker_NewHeads_FinalityViolations(t *testing.T) {
 			c.FinalityTagEnabled = ptr(true)
 			c.FinalityDepth = ptr(uint32(0))
 		})
-		orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+		orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 
 		ethClient := clienttest.NewClientWithDefaultChainID(t)
 		chStarted := make(chan struct{})
@@ -412,7 +412,7 @@ func TestHeadTracker_Start(t *testing.T) {
 		})
 		if opts.ORM == nil {
 			db := testutils.NewSqlxDB(t)
-			opts.ORM = evmheads.NewORM(*testutils.FixtureChainID, db)
+			opts.ORM = evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 		}
 		ethClient := clienttest.NewClientWithDefaultChainID(t)
 		mockEth := &clienttest.MockEth{EthClient: ethClient}
@@ -529,7 +529,7 @@ func TestHeadTracker_CallsHeadTrackableCallbacks(t *testing.T) {
 
 	db := testutils.NewSqlxDB(t)
 	config := configtest.NewChainScopedConfig(t, nil)
-	orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+	orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 
@@ -567,7 +567,7 @@ func TestHeadTracker_ReconnectOnError(t *testing.T) {
 
 	db := testutils.NewSqlxDB(t)
 	config := configtest.NewChainScopedConfig(t, nil)
-	orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+	orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 	mockEth := &clienttest.MockEth{EthClient: ethClient}
@@ -604,7 +604,7 @@ func TestHeadTracker_ResubscribeOnSubscriptionError(t *testing.T) {
 
 	db := testutils.NewSqlxDB(t)
 	config := configtest.NewChainScopedConfig(t, nil)
-	orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+	orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 
@@ -683,7 +683,7 @@ func TestHeadTracker_Start_LoadsLatestChain(t *testing.T) {
 			},
 		)
 
-	orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+	orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 	trackable := &CountingHeadTrackable{}
 	ht := createHeadTrackerWithChecker(t, ethClient, config.EVM(), config.EVM().HeadTracker(), orm, trackable)
 
@@ -725,7 +725,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 
 	checker := headstest.NewTrackable[*evmtypes.Head, common.Hash](t)
-	orm := evmheads.NewORM(*config.EVM().ChainID(), db)
+	orm := evmheads.NewORM(*config.EVM().ChainID(), db, 0)
 	ht := createHeadTrackerWithChecker(t, ethClient, config.EVM(), config.EVM().HeadTracker(), orm, checker)
 
 	chchHeaders := make(chan testutils.RawSub[*evmtypes.Head], 1)
@@ -846,7 +846,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 	ethClient := clienttest.NewClientWithDefaultChainID(t)
 
 	checker := headstest.NewTrackable[*evmtypes.Head, common.Hash](t)
-	orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+	orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 	ht := createHeadTrackerWithChecker(t, ethClient, config.EVM(), config.EVM().HeadTracker(), orm, checker)
 
 	chchHeaders := make(chan testutils.RawSub[*evmtypes.Head], 1)
@@ -972,7 +972,7 @@ func TestHeadTracker_Backfill(t *testing.T) {
 	t.Run("Enabled Persistence", func(t *testing.T) {
 		testHeadTrackerBackfill(t, func(t *testing.T) evmheads.ORM {
 			db := testutils.NewSqlxDB(t)
-			return evmheads.NewORM(*testutils.FixtureChainID, db)
+			return evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 		})
 	})
 	t.Run("Disabled Persistence", func(t *testing.T) {
@@ -1365,7 +1365,7 @@ func TestHeadTracker_LatestSafeBlock(t *testing.T) {
 		})
 
 		db := testutils.NewSqlxDB(t)
-		orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+		orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 		for i := range opts.Heads {
 			require.NoError(t, orm.IdempotentInsertHead(t.Context(), opts.Heads[i]))
 		}
@@ -1446,7 +1446,7 @@ func TestHeadTracker_LatestAndFinalizedBlock(t *testing.T) {
 		})
 
 		db := testutils.NewSqlxDB(t)
-		orm := evmheads.NewORM(*testutils.FixtureChainID, db)
+		orm := evmheads.NewORM(*testutils.FixtureChainID, db, 0)
 		for i := range opts.Heads {
 			require.NoError(t, orm.IdempotentInsertHead(tests.Context(t), opts.Heads[i]))
 		}

--- a/pkg/logpoller/orm.go
+++ b/pkg/logpoller/orm.go
@@ -576,8 +576,15 @@ func (o *DSORM) insertLogsWithinTx(ctx context.Context, logs []Log, tx sqlutil.D
 		query := `INSERT INTO evm.logs
 					(evm_chain_id, log_index, block_hash, block_number, block_timestamp, address, event_sig, topics, tx_hash, data, created_at)
 				VALUES
-					(:evm_chain_id, :log_index, :block_hash, :block_number, :block_timestamp, :address, :event_sig, :topics, :tx_hash, :data, NOW())
+					(:evm_chain_id, :log_index, :block_hash, :block_number, :block_timestamp, :address, :event_sig, :topics, :tx_hash, :data, :created_at)
 				ON CONFLICT DO NOTHING`
+
+		// explicitly set created_at to now()
+		// as now() does not work with batch inserts
+		createdAt := time.Now().UTC()
+		for _, log := range logs[start:end] {
+			log.CreatedAt = createdAt
+		}
 
 		_, err := tx.NamedExecContext(ctx, query, logs[start:end])
 		if err != nil {


### PR DESCRIPTION
HeadTracker insert/deletes are very heavy on the db because its being done per block.
We are trying to batch it here to make it more efficient.

Slack thread -> https://chainlink-core.slack.com/archives/C07PHTC2WJC/p1751473048720999

Ticket:
- https://smartcontract-it.atlassian.net/browse/PLEX-1593
- https://smartcontract-it.atlassian.net/browse/PLEX-1595