### PR TITLE
Fix for failed to read defaults on Windows

### DIFF
--- a/pkg/config/toml/defaults.go
+++ b/pkg/config/toml/defaults.go
@@ -7,7 +7,7 @@ import (
 	"io/fs"
 	"log"
 	"os"
-	"path/filepath"
+	"path"
 	"slices"
 	"strings"
 
@@ -92,7 +92,9 @@ func initDefaults(
 		}
 
 		// read the file to bytes
-		path := filepath.Join(root, entry.Name())
+		// use path.Join() instead of filepath.Join() because embed.FS uses forward slashes even on Windows
+		// see https://pkg.go.dev/io/fs#ValidPath
+		path := path.Join(root, entry.Name())
 
 		chainID, chain, err := readConfig(path, fileReader)
 		if err != nil {


### PR DESCRIPTION
We found a bug when testing a CLI tool that relies on the [chainlink core](https://github.com/smartcontractkit/chainlink) as a depedency, binary exits as soon as you run it due to a path load issue during init. Chainlink core has a transitive dependency on chainlink-evm that is causing this issue.