### PR TITLE
Add Optimism error handling and corresponding test case

### DIFF
--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -207,6 +207,11 @@ var klaytn = ClientErrors{
 	Fatal:                             gethFatal,
 }
 
+// Optimism
+var optimism = ClientErrors{
+	Fatal: regexp.MustCompile(`(: |^)oversized data: transaction size \d+, limit \d+`),
+}
+
 // Nethermind
 // All errors: https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
 // All filters: https://github.com/NethermindEth/nethermind/tree/9b68ec048c65f4b44fb863164c0dec3f7780d820/src/Nethermind/Nethermind.TxPool/Filters
@@ -308,7 +313,7 @@ var internal = ClientErrors{
 	TerminallyStuck: regexp.MustCompile(TerminallyStuckMsg),
 }
 
-var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, treasure, mantle, aStar, hedera, gnosis, sei, monad, internal}
+var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, optimism, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, treasure, mantle, aStar, hedera, gnosis, sei, monad, internal}
 
 // ClientErrorRegexes returns a map of compiled regexes for each error type
 func ClientErrorRegexes(errsRegex config.ClientErrors) *ClientErrors {

--- a/pkg/client/errors_test.go
+++ b/pkg/client/errors_test.go
@@ -455,6 +455,8 @@ func Test_Eth_Errors_Fatal(t *testing.T) {
 		{"insufficient fee", true, "Sei"},
 
 		{"Gas limit too low", true, "monad"},
+
+		{"oversized data: transaction size 138074, limit 131072", true, "Optimism"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This pull request adds support for recognizing fatal transaction errors specific to the Optimism client in the error handling logic. The main changes involve updating the error patterns and tests to ensure oversized transaction data errors from Optimism are properly detected.

**Support for Optimism client errors:**

* Added a new `optimism` entry to `ClientErrors` in `pkg/client/errors.go`, with a fatal error regex for oversized transaction data.
* Included `optimism` in the list of recognized clients in the `clients` slice, ensuring its error patterns are checked during error handling.

**Testing:**

* Added a test case to `Test_Eth_Errors_Fatal` in `pkg/client/errors_test.go` to verify detection of the Optimism oversized transaction error.