### PR TITLE
[CRE-494] Start LogPoller in the LOOPP mode.

### DIFF
--- a/pkg/chains/legacyevm/chain.go
+++ b/pkg/chains/legacyevm/chain.go
@@ -343,11 +343,8 @@ func (c *chain) Start(ctx context.Context) error {
 		// Services should be able to handle a non-functional eth client and
 		// not block start in this case, instead retrying in a background loop
 		// until it becomes available.
-		//
-		// We do not start the log poller here, it gets
-		// started after the jobs so they have a chance to apply their filters.
 		var ms services.MultiStart
-		if err := ms.Start(ctx, c.txm, c.headBroadcaster, c.headTracker, c.logBroadcaster); err != nil {
+		if err := ms.Start(ctx, c.txm, c.headBroadcaster, c.headTracker, c.logBroadcaster, c.logPoller); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Before this PR we would not start logPoller at all. After this PR we at least start it. The removed comment "it gets started after the jobs, so they have a chance to apply their filters" suggests that the logPoller should be started after other jobs, however, this does not seem to hold anymore. We checked the logs and it seems all the filters are loaded by the logPoller from the underlying db, meaning that the filter registration by the other jobs is a no-op. 