### PR TITLE
Revert "[CRE-494] Start LogPoller in the LOOPP mode."

### DIFF
--- a/pkg/chains/legacyevm/chain.go
+++ b/pkg/chains/legacyevm/chain.go
@@ -343,8 +343,11 @@ func (c *chain) Start(ctx context.Context) error {
 		// Services should be able to handle a non-functional eth client and
 		// not block start in this case, instead retrying in a background loop
 		// until it becomes available.
+		//
+		// We do not start the log poller here, it gets
+		// started after the jobs so they have a chance to apply their filters.
 		var ms services.MultiStart
-		if err := ms.Start(ctx, c.txm, c.headBroadcaster, c.headTracker, c.logBroadcaster, c.logPoller); err != nil {
+		if err := ms.Start(ctx, c.txm, c.headBroadcaster, c.headTracker, c.logBroadcaster); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Reverts smartcontractkit/chainlink-evm#217

While we start logPoller in the LOOPP mode, we now start it twice in the embedded mode which is wrong. Reverting this change until we figure out how to properly handle both cases.