### PR TITLE
Set default FinalityTagEnabled  on polygon and amoy to be false

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,3 +78,4 @@ go.sum @smartcontractkit/core @smartcontractkit/foundations @smartcontractkit/co
 
 pkg/txm @dimriou @smartcontractkit/bix-framework @smartcontractkit/core
 pkg/bindings @smartcontractkit/bix-framework
+pkg/config/toml/defaults @smartcontractkit/bix-framework

--- a/pkg/config/toml/defaults/Polygon_Amoy.toml
+++ b/pkg/config/toml/defaults/Polygon_Amoy.toml
@@ -1,5 +1,6 @@
 ChainID = '80002'
 FinalityDepth = 500
+FinalityTagEnabled = false
 LinkContractAddress = '0x0Fd9e8d3aF1aaee056EB9e802c3A762a667b1904'
 LogPollInterval = '1s'
 MinIncomingConfirmations = 5

--- a/pkg/config/toml/defaults/Polygon_Mainnet.toml
+++ b/pkg/config/toml/defaults/Polygon_Mainnet.toml
@@ -2,7 +2,7 @@
 ChainID = '137'
 # It is quite common to see re-orgs on polygon go several hundred blocks deep. See: https://polygonscan.com/blocks_forked
 FinalityDepth = 500
-FinalityTagEnabled = true
+FinalityTagEnabled = false
 LinkContractAddress = '0xb0897686c545045aFc77CF20eC7A532E3120E0F1'
 LogPollInterval = '1s'
 MinIncomingConfirmations = 5

--- a/pkg/config/toml/defaults/Polygon_Mainnet.toml
+++ b/pkg/config/toml/defaults/Polygon_Mainnet.toml
@@ -2,6 +2,7 @@
 ChainID = '137'
 # It is quite common to see re-orgs on polygon go several hundred blocks deep. See: https://polygonscan.com/blocks_forked
 FinalityDepth = 500
+# Multiple instances of finality tag being violated in past
 FinalityTagEnabled = false
 LinkContractAddress = '0xb0897686c545045aFc77CF20eC7A532E3120E0F1'
 LogPollInterval = '1s'


### PR DESCRIPTION
Multiple products have faced issue with this config as polygon has sent reorgs on blocks previously sent with finality tags.

Most products override this manually, changing the default for safety in future