### PR TITLE
Transfer ownership of L2EP to Data Growth

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 /contracts/**/*upkeep* @smartcontractkit/dev-services
 /contracts/**/*automation* @smartcontractkit/dev-services
 /contracts/**/*functions* @smartcontractkit/dev-services
-/contracts/**/*l2ep* @smartcontractkit/bix-ship
+/contracts/**/*l2ep* @smartcontractkit/data-growth
 /contracts/**/*llo-feeds* @smartcontractkit/data-streams-engineers
 /contracts/**/*operatorforwarder* @smartcontractkit/data-feeds-engineers
 /contracts/**/*data-feeds* @smartcontractkit/data-feeds-engineers
@@ -33,7 +33,7 @@
 
 /contracts/src/v0.8/automation @smartcontractkit/dev-services
 /contracts/src/v0.8/functions @smartcontractkit/dev-services
-/contracts/src/v0.8/l2ep @smartcontractkit/bix-build
+/contracts/src/v0.8/l2ep @smartcontractkit/data-growth
 /contracts/src/v0.8/llo-feeds @smartcontractkit/data-streams-engineers
 # TODO: mocks folder, folder should be removed and files moved to the correct folders
 /contracts/src/v0.8/operatorforwarder @smartcontractkit/data-feeds-engineers
@@ -58,7 +58,7 @@
 /gethwrappers/keeper @smartcontractkit/dev-services
 /gethwrappers/upkeep @smartcontractkit/dev-services
 /gethwrappers/automation @smartcontractkit/dev-services
-/gethwrappers/l2ep @smartcontractkit/bix-ship
+/gethwrappers/l2ep @smartcontractkit/data-growth
 /gethwrappers/vrf @smartcontractkit/dev-services
 
 # Remove changeset files from the codeowners


### PR DESCRIPTION
This PR updates the ownership of the L2EP contracts from BIX-Ship (deprecated) to Data Growth.