### PR TITLE
Oev 618 update max retries logic

### DIFF
--- a/pkg/txm/storage/inmemory_store.go
+++ b/pkg/txm/storage/inmemory_store.go
@@ -16,6 +16,9 @@ import (
 )
 
 const (
+	// MaxAllowedAttempts controls the maximum number of attempts stored per transactions. After this threshold is exceeded
+	// the oldest attempts will be pruned to make room for new attempts.
+	MaxAllowedAttempts = 10
 	// maxQueuedTransactions is the max limit of UnstartedTransactions and ConfirmedTransactions structures.
 	maxQueuedTransactions = 250
 	// pruneSubset controls the subset of confirmed transactions to prune when the structure reaches its max limit.
@@ -85,8 +88,13 @@ func (m *InMemoryStore) AppendAttemptToTransaction(txNonce uint64, attempt *type
 	}
 
 	attempt.CreatedAt = time.Now()
-	attempt.ID = uint64(len(tx.Attempts)) // Attempts are not collectively tracked by the in-memory store so attemptIDs are not unique between transactions and can be reused.
+	attempt.ID = uint64(tx.AttemptCount) // Attempts are not collectively tracked by the in-memory store so attemptIDs are not unique between transactions and can be reused.
 	tx.AttemptCount++
+	// Prune oldest attempt.
+	if len(tx.Attempts) >= MaxAllowedAttempts {
+		m.UnconfirmedTransactions[txNonce].Attempts[0] = nil // avoid memory leaks
+		m.UnconfirmedTransactions[txNonce].Attempts = m.UnconfirmedTransactions[txNonce].Attempts[1:]
+	}
 	m.UnconfirmedTransactions[txNonce].Attempts = append(m.UnconfirmedTransactions[txNonce].Attempts, attempt.DeepCopy())
 
 	return nil
@@ -155,8 +163,9 @@ func (m *InMemoryStore) CreateTransaction(txRequest *types.TxRequest) *types.Tra
 	if uLen >= maxQueuedTransactions {
 		m.lggr.Warnw(fmt.Sprintf("Unstarted transactions queue for address: %v reached max limit of: %d. Dropping oldest transactions", m.address, maxQueuedTransactions),
 			"txs", m.UnstartedTransactions[0:uLen-maxQueuedTransactions+1]) // need to make room for the new tx
-		for _, tx := range m.UnstartedTransactions[0 : uLen-maxQueuedTransactions+1] {
+		for i, tx := range m.UnstartedTransactions[0 : uLen-maxQueuedTransactions+1] {
 			delete(m.Transactions, tx.ID)
+			m.UnstartedTransactions[i] = nil // avoid memory leaks
 		}
 		m.UnstartedTransactions = m.UnstartedTransactions[uLen-maxQueuedTransactions+1:]
 	}

--- a/pkg/txm/storage/inmemory_store_test.go
+++ b/pkg/txm/storage/inmemory_store_test.go
@@ -104,6 +104,27 @@ func TestAppendAttemptToTransaction(t *testing.T) {
 		assert.Equal(t, uint16(1), tx.AttemptCount)
 		assert.False(t, tx.Attempts[0].CreatedAt.IsZero())
 	})
+
+	t.Run("appends attempt to transaction and prunes the oldest one if limit is reached", func(t *testing.T) {
+		m2 := NewInMemoryStore(logger.Test(t), fromAddress, testutils.FixtureChainID)
+
+		var nonce uint64 = 10
+		_, err := insertUnconfirmedTransaction(m2, nonce) // txID = 1, nonce = 10
+		require.NoError(t, err)
+
+		var attemptsTried uint16 = 12
+		for range attemptsTried {
+			newAttempt := &types.Attempt{
+				TxID: 1,
+			}
+			require.NoError(t, m2.AppendAttemptToTransaction(nonce, newAttempt))
+		}
+		tx, _ := m2.FetchUnconfirmedTransactionAtNonceWithCount(nonce)
+		fmt.Println("TX:", tx)
+		assert.Len(t, tx.Attempts, MaxAllowedAttempts)
+		assert.Equal(t, attemptsTried, tx.AttemptCount)
+		assert.Equal(t, uint64(attemptsTried-MaxAllowedAttempts), tx.Attempts[0].ID)
+	})
 }
 
 func TestCountUnstartedTransactions(t *testing.T) {

--- a/pkg/txm/stuck_tx_detector.go
+++ b/pkg/txm/stuck_tx_detector.go
@@ -47,17 +47,31 @@ func (s *stuckTxDetector) DetectStuckTransaction(ctx context.Context, tx *types.
 	}
 }
 
-// timeBasedDetection marks a transaction if all the following conditions are met:
-// - LastBroadcastAt is not nil
-// - Time since last broadcast is above the threshold
-// - Time since last purge is above threshold
+// timeBasedDetection marks a transaction if:
+//   - LastBroadcastAt is nil
+//   - Total attempt count is equal or greater than the maxAttemptsThreshold
+//
+// or all the following conditions are met:
+//   - LastBroadcastAt is not nil
+//   - Time since last broadcast is above the threshold
+//   - Time since last purge is above threshold
 //
 // NOTE: Potentially we can use a subset of threhsold for last purge check, because the transaction would have already been broadcasted to the mempool
 // so it is more likely to be picked up compared to a transaction that hasn't been broadcasted before. This would avoid slowing down TXM for sebsequent transactions
 // in case the current one is stuck.
 func (s *stuckTxDetector) timeBasedDetection(tx *types.Transaction) bool {
 	threshold := (s.config.BlockTime * time.Duration(s.config.StuckTxBlockThreshold))
-	if tx.LastBroadcastAt != nil && min(time.Since(*tx.LastBroadcastAt), time.Since(s.lastPurgeMap[tx.FromAddress])) > threshold {
+	if tx.LastBroadcastAt == nil {
+		if tx.AttemptCount >= maxAttemptsThreshold {
+			s.lggr.Debugf("TxID: %v reached max attempts threshold: %d. Transaction is now considered stuck and will be purged.",
+				tx.ID, maxAttemptsThreshold)
+			s.lastPurgeMap[tx.FromAddress] = time.Now()
+			return true
+		}
+		return false
+	}
+
+	if min(time.Since(*tx.LastBroadcastAt), time.Since(s.lastPurgeMap[tx.FromAddress])) > threshold {
 		s.lggr.Debugf("TxID: %v last broadcast was: %v and last purge: %v which is more than the max configured duration: %v. Transaction is now considered stuck and will be purged.",
 			tx.ID, tx.LastBroadcastAt, s.lastPurgeMap[tx.FromAddress], threshold)
 		s.lastPurgeMap[tx.FromAddress] = time.Now()

--- a/pkg/txm/stuck_tx_detector_test.go
+++ b/pkg/txm/stuck_tx_detector_test.go
@@ -56,6 +56,24 @@ func TestTimeBasedDetection(t *testing.T) {
 		assert.True(t, s.timeBasedDetection(tx))
 	})
 
+	t.Run("returns true if LastBroadcastAt is nil but attempt count is above threshold", func(t *testing.T) {
+		config := StuckTxDetectorConfig{
+			BlockTime:             10 * time.Second,
+			StuckTxBlockThreshold: 5,
+		}
+		fromAddress := testutils.NewAddress()
+		s := NewStuckTxDetector(logger.Test(t), "", config)
+
+		// This can happen if the transaction was broadcasted multiple times before but got no success messages.
+		tx := &types.Transaction{
+			ID:              1,
+			LastBroadcastAt: nil,
+			FromAddress:     fromAddress,
+			AttemptCount:    maxAttemptsThreshold,
+		}
+		assert.True(t, s.timeBasedDetection(tx))
+	})
+
 	t.Run("marks first tx as stuck, updates purge time for address, and returns false for the second tx with the same broadcast time", func(t *testing.T) {
 		config := StuckTxDetectorConfig{
 			BlockTime:             1 * time.Second,

--- a/pkg/txm/txm.go
+++ b/pkg/txm/txm.go
@@ -21,7 +21,7 @@ const (
 	broadcastInterval           time.Duration = 30 * time.Second
 	maxInFlightTransactions     int           = 16
 	maxInFlightSubset           int           = 5
-	maxAllowedAttempts          uint16        = 10
+	maxAttemptsThreshold        uint16        = 10
 	pendingNonceDefaultTimeout  time.Duration = 30 * time.Second
 	pendingNonceRecheckInterval time.Duration = 1 * time.Second
 )
@@ -415,14 +415,15 @@ func (t *Txm) backfillTransactions(ctx context.Context, address common.Address) 
 			}
 		}
 
-		if tx.AttemptCount >= maxAllowedAttempts {
+		if tx.AttemptCount >= maxAttemptsThreshold {
 			t.metrics.ReachedMaxAttempts(ctx, true)
-			return true, fmt.Errorf("reached max allowed attempts for txID: %d. TXM won't broadcast any more attempts."+
-				"If this error persists, it means the transaction won't be confirmed and the TXM needs to be restarted."+
+			t.lggr.Warnf("Reached max attempts threshold for txID: %d. TXM will broadcast more attempts  but if this"+
+				" error persists, it means the transaction won't likely be confirmed and there is an issue with the transaction."+
 				"Look for any error messages from previous broadcasted attempts that may indicate why this happened, i.e. wallet is out of funds. Tx: %v", tx.ID,
 				tx.PrintWithAttempts())
+		} else {
+			t.metrics.ReachedMaxAttempts(ctx, false)
 		}
-		t.metrics.ReachedMaxAttempts(ctx, false)
 
 		if tx.LastBroadcastAt == nil || time.Since(*tx.LastBroadcastAt) > (t.config.BlockTime*time.Duration(t.config.RetryBlockThreshold)) {
 			// TODO: add optional graceful bumping strategy

--- a/pkg/txm/txm_test.go
+++ b/pkg/txm/txm_test.go
@@ -321,4 +321,57 @@ func TestBackfillTransactions(t *testing.T) {
 		require.NoError(t, err)
 		tests.AssertLogEventually(t, observedLogs, fmt.Sprintf("Rebroadcasting attempt for txID: %d", attempt.TxID))
 	})
+
+	t.Run("fetches the unconfirmed transaction for a given nonce, throws a warning for max limit and retries with a new attempt", func(t *testing.T) {
+		ctx := t.Context()
+		lggr, observedLogs := logger.TestObserved(t, zap.DebugLevel)
+		txStore := storage.NewInMemoryStoreManager(lggr, testutils.FixtureChainID)
+		require.NoError(t, txStore.Add(address))
+		txm := NewTxm(lggr, testutils.FixtureChainID, client, ab, txStore, nil, config, keystore)
+		var nonce uint64 = 8
+		txm.setNonce(address, nonce)
+		metrics, err := NewTxmMetrics(testutils.FixtureChainID)
+		require.NoError(t, err)
+		txm.metrics = metrics
+		IDK := "IDK"
+		txRequest := &types.TxRequest{
+			Data:              []byte{100, 200},
+			IdempotencyKey:    &IDK,
+			ChainID:           testutils.FixtureChainID,
+			FromAddress:       address,
+			ToAddress:         testutils.NewAddress(),
+			SpecifiedGasLimit: 22000,
+		}
+		tx, err := txm.CreateTransaction(t.Context(), txRequest)
+		require.NoError(t, err)
+		_, err = txStore.UpdateUnstartedTransactionWithNonce(ctx, address, nonce)
+		require.NoError(t, err)
+
+		attempt := &types.Attempt{
+			TxID:     tx.ID,
+			Fee:      gas.EvmFee{GasPrice: assets.NewWeiI(1)},
+			GasLimit: 22000,
+		}
+		var attemptsTried uint16 = storage.MaxAllowedAttempts + 2
+		for range attemptsTried {
+			require.NoError(t, txStore.AppendAttemptToTransaction(ctx, nonce, address, attempt))
+		}
+		client.On("NonceAt", mock.Anything, address, mock.Anything).Return(nonce, nil).Once()
+		ab.On("NewAttempt", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(attempt, nil).Once()
+		client.On("SendTransaction", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+		_, err = txm.backfillTransactions(ctx, address)
+		require.NoError(t, err)
+
+		tx2, err := txStore.FindTxWithIdempotencyKey(t.Context(), IDK)
+		require.NoError(t, err)
+		assert.Len(t, tx2.Attempts, storage.MaxAllowedAttempts)
+		assert.Equal(t, attemptsTried+1, tx2.AttemptCount) // the initial attempts tried, plus the one during backfill
+		var zeroTime time.Time
+		assert.Greater(t, *tx2.LastBroadcastAt, zeroTime)
+		assert.Greater(t, *tx2.Attempts[0].BroadcastAt, zeroTime)
+		assert.Greater(t, *tx2.InitialBroadcastAt, zeroTime)
+		assert.Equal(t, uint64(attemptsTried-storage.MaxAllowedAttempts+1), tx2.Attempts[0].ID) // the initial attempts tried, plus the one during backfill
+		tests.AssertLogEventually(t, observedLogs, fmt.Sprintf("Reached max attempts threshold for txID: %d", 0))
+	})
 }


### PR DESCRIPTION
This PR implements two new changes:

1. Updates max retries logic: TXM no longer stops rebroadcasting new attempts for transactions that have reached the maximum threshold. Instead, it throws an error, purges old attempts, and retries. You should now rely exclusively on monitoring to catch abnormalities in broadcasting.
2. Updates time-based stuck transaction logic: along with the time-based heuristic, the time-based method also adds a max attempts threshold heuristic, even if the transaction has no successful broadcasts.