### PR TITLE
fix onlyBuiltDependencies  & readme pnpm i

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -69,7 +69,7 @@ Please refrain from using these in production applications.
 # Clone Chainlink repository
 $ git clone https://github.com/smartcontractkit/chainlink.git
 $ cd contracts/
-$ pnpm
+$ pnpm i
 ```
 
 Each Chainlink project has its own directory under `src/` which can be targeted using Foundry profiles.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -67,7 +67,7 @@ Please refrain from using these in production applications.
 
 ```bash
 # Clone Chainlink repository
-$ git clone https://github.com/smartcontractkit/chainlink.git
+$ git clone https://github.com/smartcontractkit/chainlink-evm.git
 $ cd contracts/
 $ pnpm i
 ```

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -38,15 +38,7 @@
       "minimatch@5.1.6>brace-expansion": "^2.0.2",
       "minimatch@9.0.5>brace-expansion": "^2.0.2"
     },
-    "onlyBuiltDependencies": [
-      "// keccak@3.0.4, secp256k1@4.0.4 run node-gyp-build during install",
-      "// core-js@3.4.0 has a postinstall script to print a banner",
-      "// @arbitrum/nitro-contracts@1.1.1 has a postinstall script that runs patch-package. But has no patches.",
-      "secp256k1",
-      "keccak",
-      "core-js",
-      "@arbitrum/nitro-contracts"
-    ]
+    "onlyBuiltDependencies": []
   },
   "engines": {
     "node": ">=22",


### PR DESCRIPTION
Fixes an issue with the syntax used in onlyBuiltDependencies

Fixes the install command in the readme


NOTE: The Solidity linter is complaining, since this is unrelated to this PR, it will not be addressed here.