### PR TITLE
Plex 1880

### DIFF
--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -1160,8 +1160,15 @@ func (r *RPCClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) (l [
 
 	lggr.Debug("RPC call: evmclient.Client#FilterLogs")
 	start := time.Now()
-	l, err = client.geth.FilterLogs(ctx, q)
+	arg, err := toFilterArg(q)
+	if err != nil {
+		return nil, err
+	}
+
+	var result evmtypes.Logs
+	err = client.rpc.CallContext(ctx, &result, "eth_getLogs", arg)
 	err = r.wrapRPCClientError(err)
+	l = result.AsGethLogs()
 
 	if err == nil {
 		err = r.makeLogsValid(l)
@@ -1171,7 +1178,7 @@ func (r *RPCClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) (l [
 		"log", l,
 	)
 
-	return
+	return l, nil
 }
 
 // FilterLogsWithOpts executes a filter query.

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -1178,7 +1178,7 @@ func (r *RPCClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) (l [
 		"log", l,
 	)
 
-	return l, nil
+	return l, err
 }
 
 // FilterLogsWithOpts executes a filter query.

--- a/pkg/client/rpc_client_test.go
+++ b/pkg/client/rpc_client_test.go
@@ -522,6 +522,7 @@ func TestRPCClientFilterLogs(t *testing.T) {
 				require.NoError(t, rpc.Dial(ctx))
 				logs, err := rpc.FilterLogs(ctx, ethereum.FilterQuery{})
 				require.NoError(t, err)
+				require.Equal(t, len(testCases), len(logs), "Unexpected amount of logs returned")
 				for i, testCase := range testCases {
 					require.Equal(t, testCase.ExpectedIndex, logs[i].Index, "Unexpected log index %d for test case %v", logs[i].Index, testCase)
 				}
@@ -535,6 +536,7 @@ func TestRPCClientFilterLogs(t *testing.T) {
 			require.NoError(t, rpc.Dial(ctx))
 			logs, err := rpc.FilterLogs(ctx, ethereum.FilterQuery{})
 			require.NoError(t, err)
+			require.Equal(t, len(testCases), len(logs), "Unexpected amount of logs returned")
 			for i, testCase := range testCases {
 				require.Equal(t, testCase.Index, logs[i].Index, "Expected other chains log to be returned as is")
 				require.Equal(t, testCase.TxIndex, logs[i].TxIndex, "Expected other chains log to be returned as is")

--- a/pkg/client/rpc_client_test.go
+++ b/pkg/client/rpc_client_test.go
@@ -463,6 +463,96 @@ func TestRPCClient_SubscribeFilterLogs(t *testing.T) {
 	})
 }
 
+func TestRPCClientFilterLogsCompatibility(t *testing.T) {
+	t.Parallel()
+
+	topics := []common.Hash{common.BigToHash(big.NewInt(10))}
+
+	const (
+		expAddress        = "0xecf8f87f810ecf450940c9f60066b4a7a501d6a7"
+		expBlockHash      = "0x656c34545f90a730a19008c0e7a7cd4fb3895064b48d6d69761bd5abad681056"
+		expBlockNumberHex = "0x1ecfa4" // 2020004 decimal
+		expBlockTimestamp = uint64(15) // 0xf
+		expData           = "0x000000000000000000000000000000000000000000000001a055690d9db80000"
+		expLogIndexHex    = "0x2"
+		expTxHash         = "0x3b198bfd5d2907285af009e9ae84a0ecd63677110d89d7e030251acb87f6487e"
+		expTxIndexHex     = "0x3"
+
+		expTopic0 = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+		expTopic1 = "0x00000000000000000000000080b2c9d7cbbf30a1b0fc8983c647d754c6525615"
+	)
+
+	expBlockNumber := uint64(0x1ecfa4)
+	expLogIndex := uint(0x2)
+	expTxIndex := uint(0x3)
+
+	tt := []struct {
+		name   string
+		logStr string
+	}{
+		{
+			name:   "return log in eth 1.16.2 format",
+			logStr: `[{"address":"` + expAddress + `","blockHash":"` + expBlockHash + `","blockNumber":"` + expBlockNumberHex + `","blockTimestamp":"0xf","data":"` + expData + `","logIndex":"` + expLogIndexHex + `","topics":["` + expTopic0 + `","` + expTopic1 + `"],"transactionHash":"` + expTxHash + `","transactionIndex":"` + expTxIndexHex + `"}]`,
+		},
+		{
+			name:   "return log in eth 1.15.3 format",
+			logStr: `[{"address":"` + expAddress + `","blockHash":"` + expBlockHash + `","blockNumber":"` + expBlockNumberHex + `","blockTimestamp":15,"data":"` + expData + `","logIndex":"` + expLogIndexHex + `","topics":["` + expTopic0 + `","` + expTopic1 + `"],"transactionHash":"` + expTxHash + `","transactionIndex":"` + expTxIndexHex + `"}]`,
+		},
+	}
+
+	for _, tcase := range tt {
+		t.Run(tcase.name, func(t *testing.T) {
+			wsURL := testutils.NewWSServer(t, testutils.FixtureChainID, func(method string, params gjson.Result) (resp testutils.JSONRPCResponse) {
+				switch method {
+				case "eth_getLogs":
+					resp.Result = tcase.logStr
+				default:
+					require.Fail(t, "unexpected method: "+method)
+				}
+				return
+			}).WSURL()
+
+			rpcClient := client.NewDialedTestRPCClient(t, client.RPCClientOpts{WS: wsURL, FinalityTagsEnabled: true})
+			filter := ethereum.FilterQuery{
+				FromBlock: big.NewInt(0),
+				ToBlock:   big.NewInt(10),
+				Topics:    [][]common.Hash{topics},
+			}
+
+			// CALL
+			got, err := rpcClient.FilterLogs(t.Context(), filter)
+			require.NoError(t, err)
+
+			// ASSERT: one log
+			require.Len(t, got, 1)
+			l := got[0]
+
+			// Address / Hashes
+			require.Equal(t, common.HexToAddress(expAddress), l.Address)
+			require.Equal(t, common.HexToHash(expBlockHash), l.BlockHash)
+			require.Equal(t, common.HexToHash(expTxHash), l.TxHash)
+
+			// Numbers
+			require.Equal(t, expBlockNumber, l.BlockNumber)
+			require.Equal(t, expBlockTimestamp, l.BlockTimestamp)
+			require.Equal(t, expLogIndex, l.Index)
+			require.Equal(t, expTxIndex, l.TxIndex)
+
+			// Data
+			expDataBytes, err := hexutil.Decode(expData)
+			require.NoError(t, err)
+			require.Equal(t, expDataBytes, l.Data)
+
+			// Topics
+			require.Len(t, l.Topics, 2)
+			require.Equal(t, common.HexToHash(expTopic0), l.Topics[0])
+			require.Equal(t, common.HexToHash(expTopic1), l.Topics[1])
+
+			// Removed should default to false if not provided
+			require.False(t, l.Removed)
+		})
+	}
+}
 func TestRPCClientFilterLogs(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/types/models.go
+++ b/pkg/types/models.go
@@ -669,3 +669,176 @@ func fromInternalTxnSlice(tis []blocks.TransactionInternal) []Transaction {
 	}
 	return out
 }
+
+// LogMarshalling is a compatibility wrapper for go-ethereum's types.Log JSON format.
+// It unmarshals blockTimestamp from either a JSON number (e.g. 30) or a hex string
+// (e.g. "0x1e"). MarshalJSON always emits hex strings for numeric fields.
+type LogMarshalling struct {
+	Address        common.Address
+	Topics         []common.Hash
+	Data           []byte
+	BlockNumber    uint64
+	TxHash         common.Hash
+	TxIndex        uint
+	BlockHash      common.Hash
+	BlockTimestamp uint64
+	Index          uint
+	Removed        bool
+}
+
+type Logs []LogMarshalling
+
+func (l Logs) AsGethLogs() []types.Log {
+	ret := make([]types.Log, len(l))
+	for i, log := range l {
+		ret[i] = log.AsGethLog()
+	}
+
+	return ret
+}
+
+func (lm LogMarshalling) AsGethLog() types.Log {
+	return types.Log{
+		Address:        lm.Address,
+		Topics:         lm.Topics,
+		Data:           lm.Data,
+		BlockNumber:    lm.BlockNumber,
+		TxHash:         lm.TxHash,
+		TxIndex:        lm.TxIndex,
+		BlockHash:      lm.BlockHash,
+		BlockTimestamp: lm.BlockTimestamp, // present in geth v1.16.2+
+		Index:          lm.Index,
+		Removed:        lm.Removed,
+	}
+}
+
+func (lm *LogMarshalling) MarshalJSON() ([]byte, error) {
+	type enc struct {
+		Address        common.Address `json:"address"`
+		Topics         []common.Hash  `json:"topics"`
+		Data           hexutil.Bytes  `json:"data"`
+		BlockNumber    hexutil.Uint64 `json:"blockNumber"`
+		TxHash         common.Hash    `json:"transactionHash"`
+		TxIndex        hexutil.Uint   `json:"transactionIndex"`
+		BlockHash      common.Hash    `json:"blockHash"`
+		BlockTimestamp hexutil.Uint64 `json:"blockTimestamp"`
+		Index          hexutil.Uint   `json:"logIndex"`
+		Removed        bool           `json:"removed"`
+	}
+
+	out := enc{
+		Address:        lm.Address,
+		Topics:         lm.Topics,
+		Data:           hexutil.Bytes(lm.Data),
+		BlockNumber:    hexutil.Uint64(lm.BlockNumber),
+		TxHash:         lm.TxHash,
+		TxIndex:        hexutil.Uint(lm.TxIndex),
+		BlockHash:      lm.BlockHash,
+		BlockTimestamp: hexutil.Uint64(lm.BlockTimestamp),
+		Index:          hexutil.Uint(lm.Index),
+		Removed:        lm.Removed,
+	}
+	return json.Marshal(&out)
+}
+
+func (lm *LogMarshalling) UnmarshalJSON(input []byte) error {
+	// We accept either numeric or hex string for blockTimestamp.
+	type dec struct {
+		Address        *common.Address `json:"address"`
+		Topics         []common.Hash   `json:"topics"`
+		Data           *hexutil.Bytes  `json:"data"`
+		BlockNumber    *hexutil.Uint64 `json:"blockNumber"`
+		TxHash         *common.Hash    `json:"transactionHash"`
+		TxIndex        *hexutil.Uint   `json:"transactionIndex"`
+		BlockHash      *common.Hash    `json:"blockHash"`
+		BlockTimestamp json.RawMessage `json:"blockTimestamp"`
+		Index          *hexutil.Uint   `json:"logIndex"`
+		Removed        *bool           `json:"removed"`
+	}
+
+	var d dec
+	if err := json.Unmarshal(input, &d); err != nil {
+		return err
+	}
+
+	// Required-ish fields (match geth behavior of erroring on missing required ones if you prefer).
+	if d.Address != nil {
+		lm.Address = *d.Address
+	}
+	if d.Data != nil {
+		lm.Data = *d.Data
+	}
+	if d.BlockNumber != nil {
+		lm.BlockNumber = uint64(*d.BlockNumber)
+	}
+	if d.TxHash != nil {
+		lm.TxHash = *d.TxHash
+	}
+	if d.TxIndex != nil {
+		lm.TxIndex = uint(*d.TxIndex)
+	}
+	if d.BlockHash != nil {
+		lm.BlockHash = *d.BlockHash
+	}
+	if len(d.BlockTimestamp) != 0 {
+		ts, err := parseUint64Permissive(d.BlockTimestamp)
+		if err != nil {
+			return fmt.Errorf("blockTimestamp: %w", err)
+		}
+		lm.BlockTimestamp = ts
+	}
+	if d.Index != nil {
+		lm.Index = uint(*d.Index)
+	}
+	if d.Removed != nil {
+		lm.Removed = *d.Removed
+	}
+	// Topics can be empty, that's fine.
+	lm.Topics = d.Topics
+
+	return nil
+}
+
+func parseUint64Permissive(raw json.RawMessage) (uint64, error) {
+	if len(raw) == 0 {
+		return 0, nil
+	}
+
+	// Try as string first
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		// Hex string like "0x1e"
+		if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+			var hu hexutil.Uint64
+			if err := hu.UnmarshalText([]byte(s)); err != nil {
+				return 0, err
+			}
+			return uint64(hu), nil
+		}
+		// Decimal string like "30"
+		if ui, err := strconv.ParseUint(s, 10, 64); err == nil {
+			return ui, nil
+		}
+		// Fall through to try other forms.
+	}
+
+	// Try as hexutil.Uint64 directly (works if raw was a quoted hex string)
+	var hu hexutil.Uint64
+	if err := json.Unmarshal(raw, &hu); err == nil {
+		return uint64(hu), nil
+	}
+
+	// Try as plain unsigned number
+	var u64 uint64
+	if err := json.Unmarshal(raw, &u64); err == nil {
+		return u64, nil
+	}
+
+	// Try as signed number (non-negative)
+	var i64 int64
+	if err := json.Unmarshal(raw, &i64); err == nil && i64 >= 0 {
+		return uint64(i64), nil
+	}
+
+	return 0, fmt.Errorf("cannot parse uint64 from %s", string(raw))
+}


### PR DESCRIPTION
[JIRA](https://smartcontract-it.atlassian.net/browse/PLEX-1880)
desc:
add a drop-in wrapper that can decode blockTimestamp whether it’s a plain JSON number (old geth / some RPCs) or a hex string (new geth ≥ 1.16.2)