### PR TITLE
Clean up gas estimator after GetMaxDynamicFee method was added

### DIFF
--- a/pkg/gas/arbitrum_estimator.go
+++ b/pkg/gas/arbitrum_estimator.go
@@ -143,6 +143,12 @@ func (a *arbitrumEstimator) GetLegacyGas(ctx context.Context, calldata []byte, l
 	return
 }
 
+// GetMaxLegacyGas returns the result of GetLegacyGas. Arbitrum doesn't have a mempool. That means transaction priority follows a FIFO model.
+// Fetching a standard gas estimation will have the same effect for transaction inclusion.
+func (a *arbitrumEstimator) GetMaxLegacyGas(ctx context.Context, calldata []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) {
+	return a.GetLegacyGas(ctx, calldata, gasLimit, maxGasPriceWei, opts...)
+}
+
 // During network congestion Arbitrum's suggested gas price can be extremely volatile, making gas estimations less accurate. For any transaction, Arbitrum will only charge
 // the block's base fee. If the base fee increases rapidly there is a chance the suggested gas price will fall under that value, resulting in a fee too low error.
 // We use gasPriceWithBuffer to increase the estimated gas price by some percentage to avoid fee too low errors. Eventually, only the base fee will be paid, regardless of the price.

--- a/pkg/gas/block_history_estimator.go
+++ b/pkg/gas/block_history_estimator.go
@@ -260,16 +260,15 @@ func (b *BlockHistoryEstimator) GetMaxLegacyGas(_ context.Context, _ []byte, _ u
 
 	ok := b.IfStarted(func() {
 		gasPrice = b.getMaxPercentileGasPrice()
-		if gasPrice == nil {
-			err = errors.New("BlockHistoryEstimator has not finished the first gas estimation yet")
-			return
-		}
 	})
 	if !ok {
 		return gasPrice, 0, errors.New("BlockHistoryEstimator is not started")
 	}
 	if !b.initialFetch.Load() {
 		return gasPrice, 0, errors.New("BlockHistoryEstimator has not finished the first gas estimation yet, likely because a failure on start")
+	}
+	if gasPrice == nil {
+		return gasPrice, 0, errors.New("BlockHistoryEstimator has not finished the first gas estimation yet")
 	}
 	return gasPrice, 0, nil
 }

--- a/pkg/gas/block_history_estimator.go
+++ b/pkg/gas/block_history_estimator.go
@@ -78,13 +78,11 @@ const BumpingHaltedLabel = "Tx gas bumping halted since price exceeds current bl
 
 var _ EvmEstimator = &BlockHistoryEstimator{}
 
-type estimatorGasEstimatorConfig interface {
+type BlockHistoryEstimatorConfig interface {
 	EIP1559DynamicFees() bool
 	BumpThreshold() uint64
 	PriceDefault() *assets.Wei
-	TipCapDefault() *assets.Wei
 	TipCapMin() *assets.Wei
-	PriceMax() *assets.Wei
 	PriceMin() *assets.Wei
 	bumpConfig
 }
@@ -94,7 +92,7 @@ type BlockHistoryEstimator struct {
 	ethClient feeEstimatorClient
 	chainID   *big.Int
 	chaintype chaintype.ChainType
-	eConfig   estimatorGasEstimatorConfig
+	eConfig   BlockHistoryEstimatorConfig
 	bhConfig  evmconfig.BlockHistory
 	// NOTE: it is assumed that blocks will be kept sorted by
 	// block number ascending
@@ -123,7 +121,7 @@ type BlockHistoryEstimator struct {
 // NewBlockHistoryEstimator returns a new BlockHistoryEstimator that listens
 // for new heads and updates the base gas price dynamically based on the
 // configured percentile of gas prices in that block
-func NewBlockHistoryEstimator(lggr logger.Logger, ethClient feeEstimatorClient, chaintype chaintype.ChainType, eCfg estimatorGasEstimatorConfig, bhCfg evmconfig.BlockHistory, chainID *big.Int, l1Oracle rollups.L1Oracle) EvmEstimator {
+func NewBlockHistoryEstimator(lggr logger.Logger, ethClient feeEstimatorClient, chaintype chaintype.ChainType, eCfg BlockHistoryEstimatorConfig, bhCfg evmconfig.BlockHistory, chainID *big.Int, l1Oracle rollups.L1Oracle) EvmEstimator {
 	return &BlockHistoryEstimator{
 		ethClient: ethClient,
 		chainID:   chainID,
@@ -253,6 +251,27 @@ func (b *BlockHistoryEstimator) GetLegacyGas(_ context.Context, _ []byte, gasLim
 	gasPrice = capGasPrice(gasPrice, maxGasPriceWei, b.eConfig.PriceMax())
 	chainSpecificGasLimit = gasLimit
 	return
+}
+
+func (b *BlockHistoryEstimator) GetMaxLegacyGas(_ context.Context, _ []byte, _ uint64, maxGasPriceWei *assets.Wei, _ ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) {
+	if b.eConfig.EIP1559DynamicFees() {
+		return gasPrice, 0, errors.New("can't get max legacy gas, EIP1559 is enabled")
+	}
+
+	ok := b.IfStarted(func() {
+		gasPrice = b.getMaxPercentileGasPrice()
+		if gasPrice == nil {
+			err = errors.New("BlockHistoryEstimator has not finished the first gas estimation yet")
+			return
+		}
+	})
+	if !ok {
+		return gasPrice, 0, errors.New("BlockHistoryEstimator is not started")
+	}
+	if !b.initialFetch.Load() {
+		return gasPrice, 0, errors.New("BlockHistoryEstimator has not finished the first gas estimation yet, likely because a failure on start")
+	}
+	return gasPrice, 0, nil
 }
 
 func (b *BlockHistoryEstimator) getGasPrice() *assets.Wei {
@@ -454,7 +473,7 @@ func (b *BlockHistoryEstimator) GetMaxDynamicFee(maxGasPriceWei *assets.Wei) (fe
 	}
 	currentBaseFee := b.getCurrentBaseFee()
 	if maxTipCap == nil || currentBaseFee == nil {
-		return fee, errors.New("BlockHistoryEstimator: no value for latest block base fee or tip cap")
+		return fee, fmt.Errorf("BlockHistoryEstimator: no value for latest block base fee or tip cap: maxTipCap: %v, currentBaseFee: %v", maxTipCap, currentBaseFee)
 	}
 	maxFeeCap := calcFeeCap(currentBaseFee, int(b.bhConfig.EIP1559FeeCapBufferBlocks()), maxTipCap, maxGasPriceWei)
 	return DynamicFee{GasFeeCap: maxFeeCap, GasTipCap: maxTipCap}, nil
@@ -996,6 +1015,11 @@ func (b *BlockHistoryEstimator) EffectiveTipCap(block evmtypes.Block, tx evmtype
 		b.logger.Debugw(fmt.Sprintf("Ignoring unknown transaction type %v", tx.Type), "block", block, "tx", tx)
 		return nil
 	}
+}
+
+func capGasPrice(calculatedGasPrice, userSpecifiedMax, maxGasPriceWei *assets.Wei) *assets.Wei {
+	maxGasPrice := fees.CalculateFee(calculatedGasPrice.ToInt(), userSpecifiedMax.ToInt(), maxGasPriceWei.ToInt())
+	return assets.NewWei(maxGasPrice)
 }
 
 // Int64ToHex formats an int64 as a hex string with 0x prefix.

--- a/pkg/gas/block_history_estimator_test.go
+++ b/pkg/gas/block_history_estimator_test.go
@@ -47,11 +47,11 @@ func newBlockHistoryConfig() *gas.MockBlockHistoryConfig {
 	return c
 }
 
-func newBlockHistoryEstimatorWithChainID(t *testing.T, c evmclient.Client, chaintype chaintype.ChainType, gCfg gas.GasEstimatorConfig, bhCfg evmconfig.BlockHistory, cid *big.Int, l1Oracle rollups.L1Oracle) gas.EvmEstimator {
+func newBlockHistoryEstimatorWithChainID(t *testing.T, c evmclient.Client, chaintype chaintype.ChainType, gCfg gas.BlockHistoryEstimatorConfig, bhCfg evmconfig.BlockHistory, cid *big.Int, l1Oracle rollups.L1Oracle) gas.EvmEstimator {
 	return gas.NewBlockHistoryEstimator(logger.Test(t), c, chaintype, gCfg, bhCfg, cid, l1Oracle)
 }
 
-func newBlockHistoryEstimator(t *testing.T, c evmclient.Client, chaintype chaintype.ChainType, gCfg gas.GasEstimatorConfig, bhCfg evmconfig.BlockHistory, l1Oracle rollups.L1Oracle) *gas.BlockHistoryEstimator {
+func newBlockHistoryEstimator(t *testing.T, c evmclient.Client, chaintype chaintype.ChainType, gCfg gas.BlockHistoryEstimatorConfig, bhCfg evmconfig.BlockHistory, l1Oracle rollups.L1Oracle) *gas.BlockHistoryEstimator {
 	iface := newBlockHistoryEstimatorWithChainID(t, c, chaintype, gCfg, bhCfg, testutils.FixtureChainID, l1Oracle)
 	return gas.BlockHistoryEstimatorFromInterface(iface)
 }
@@ -1982,6 +1982,295 @@ func TestBlockHistoryEstimator_GetLegacyGas(t *testing.T) {
 
 		assert.Equal(t, assets.NewWeiI(700), fee)
 		assert.Equal(t, 10000, int(limit))
+	})
+}
+
+func TestBlockHistoryEstimator_GetMaxLegacyGas(t *testing.T) {
+	t.Parallel()
+	l1Oracle := rollupMocks.NewL1Oracle(t)
+
+	bhCfg := newBlockHistoryConfig()
+	bhCfg.TransactionPercentileF = uint16(35)
+	bhCfg.BlockHistorySizeF = uint16(8)
+	bhCfg.CheckInclusionBlocksF = uint16(4)
+	bhCfg.CheckInclusionPercentileF = uint16(90)
+
+	maxGasPrice := assets.NewWeiI(1000000)
+	geCfg := &gas.MockGasEstimatorConfig{}
+	geCfg.EIP1559DynamicFeesF = false
+	geCfg.PriceMaxF = maxGasPrice
+	geCfg.PriceMinF = assets.NewWeiI(0)
+
+	t.Run("returns error when EIP1559 is enabled", func(t *testing.T) {
+		geCfg.EIP1559DynamicFeesF = true
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+		gas.SimulateStart(t, bhe)
+
+		gasPrice, limit, err := bhe.GetMaxLegacyGas(t.Context(), make([]byte, 0), 10000, maxGasPrice)
+		require.Error(t, err)
+		assert.Equal(t, "can't get max legacy gas, EIP1559 is enabled", err.Error())
+		assert.Nil(t, gasPrice)
+		assert.Equal(t, uint64(0), limit)
+	})
+
+	t.Run("returns error when estimator is not started", func(t *testing.T) {
+		geCfg.EIP1559DynamicFeesF = false
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+		// Don't start the estimator
+
+		gasPrice, limit, err := bhe.GetMaxLegacyGas(t.Context(), make([]byte, 0), 10000, maxGasPrice)
+		require.Error(t, err)
+		assert.Equal(t, "BlockHistoryEstimator is not started", err.Error())
+		assert.Nil(t, gasPrice)
+		assert.Equal(t, uint64(0), limit)
+	})
+
+	t.Run("returns error when initialFetch is false", func(t *testing.T) {
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+		gas.SimulateStart(t, bhe)
+		// Don't set initialFetch to true
+
+		gasPrice, limit, err := bhe.GetMaxLegacyGas(tests.Context(t), make([]byte, 0), 10000, maxGasPrice)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "BlockHistoryEstimator has not finished the first gas estimation yet")
+		assert.Nil(t, gasPrice)
+		assert.Equal(t, uint64(0), limit)
+	})
+
+	t.Run("returns max gas price", func(t *testing.T) {
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+
+		// Create blocks with different gas prices
+		// CheckInclusionBlocks is 4, so we need at least 4 blocks
+		// CheckInclusionPercentile is 90, so we expect the 90th percentile price
+		blocks := []evmtypes.Block{
+			{
+				Number:       0,
+				Hash:         utils.NewHash(),
+				Transactions: legacyTransactionsFromGasPrices(1000, 2000, 3000, 4000, 5000),
+			},
+			{
+				Number:       1,
+				Hash:         utils.NewHash(),
+				Transactions: legacyTransactionsFromGasPrices(1500, 2500, 3500, 4500, 5500),
+			},
+			{
+				Number:       2,
+				Hash:         utils.NewHash(),
+				Transactions: legacyTransactionsFromGasPrices(1200, 2200, 3200, 4200, 5200),
+			},
+			{
+				Number:       3,
+				Hash:         utils.NewHash(),
+				Transactions: legacyTransactionsFromGasPrices(1800, 2800, 3800, 4800, 5800),
+			},
+		}
+
+		gas.SetRollingBlockHistory(bhe, blocks)
+		bhe.Recalculate(testutils.Head(3))
+		gas.SimulateStart(t, bhe)
+
+		// Set initialFetch to true to simulate successful start
+		gas.SetInitialFetch(bhe, true)
+
+		gasPrice, limit, err := bhe.GetMaxLegacyGas(t.Context(), make([]byte, 0), 10000, maxGasPrice)
+		require.NoError(t, err)
+		require.NotNil(t, gasPrice)
+		// The max percentile gas price should be set based on CheckInclusionPercentile (90th percentile)
+		// from the last CheckInclusionBlocks (4) blocks
+		assert.Greater(t, gasPrice.Int64(), int64(0))
+		assert.Equal(t, uint64(0), limit) // GetMaxLegacyGas always returns 0 for chainSpecificGasLimit
+
+		// Verify it matches the max percentile gas price
+		expectedMaxPercentileGasPrice := gas.GetMaxPercentileGasPrice(bhe)
+		assert.Equal(t, expectedMaxPercentileGasPrice, gasPrice)
+	})
+}
+
+func TestBlockHistoryEstimator_GetMaxDynamicFee(t *testing.T) {
+	t.Parallel()
+	l1Oracle := rollupMocks.NewL1Oracle(t)
+
+	bhCfg := newBlockHistoryConfig()
+	bhCfg.TransactionPercentileF = uint16(35)
+	bhCfg.BlockHistorySizeF = uint16(8)
+	bhCfg.CheckInclusionBlocksF = uint16(4)
+	bhCfg.CheckInclusionPercentileF = uint16(90)
+	bhCfg.EIP1559FeeCapBufferBlocksF = uint16(4)
+
+	maxGasPrice := assets.NewWeiI(1000000)
+	geCfg := &gas.MockGasEstimatorConfig{}
+	geCfg.EIP1559DynamicFeesF = true
+	geCfg.PriceMaxF = maxGasPrice
+	geCfg.PriceMinF = assets.NewWeiI(0)
+	geCfg.TipCapMinF = assets.NewWeiI(0)
+
+	t.Run("returns error when EIP1559 is disabled", func(t *testing.T) {
+		geCfg.EIP1559DynamicFeesF = false
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+		gas.SimulateStart(t, bhe)
+
+		fee, err := bhe.GetMaxDynamicFee(maxGasPrice)
+		require.Error(t, err)
+		assert.Equal(t, "can't get dynamic fee, EIP1559 is disabled", err.Error())
+		assert.Equal(t, gas.DynamicFee{}, fee)
+	})
+
+	t.Run("returns error when estimator is not started", func(t *testing.T) {
+		geCfg.EIP1559DynamicFeesF = true
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+		// Don't start the estimator
+
+		fee, err := bhe.GetMaxDynamicFee(maxGasPrice)
+		require.Error(t, err)
+		assert.Equal(t, "BlockHistoryEstimator is not started", err.Error())
+		assert.Equal(t, gas.DynamicFee{}, fee)
+	})
+
+	t.Run("returns error when initialFetch is false", func(t *testing.T) {
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+		gas.SimulateStart(t, bhe)
+		// Don't set initialFetch to true
+
+		fee, err := bhe.GetMaxDynamicFee(maxGasPrice)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "BlockHistoryEstimator has not finished the first gas estimation yet")
+		assert.Equal(t, gas.DynamicFee{}, fee)
+	})
+
+	t.Run("returns error when maxTipCap is nil", func(t *testing.T) {
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+
+		// Create blocks with no transactions (will cause maxTipCap calculation to fail)
+		blocks := []evmtypes.Block{
+			{
+				BaseFeePerGas: assets.NewWeiI(100000),
+				Number:        0,
+				Hash:          utils.NewHash(),
+				Transactions:  []evmtypes.Transaction{},
+			},
+			{
+				BaseFeePerGas: assets.NewWeiI(100000),
+				Number:        1,
+				Hash:          utils.NewHash(),
+				Transactions:  []evmtypes.Transaction{},
+			},
+			{
+				BaseFeePerGas: assets.NewWeiI(100000),
+				Number:        2,
+				Hash:          utils.NewHash(),
+				Transactions:  []evmtypes.Transaction{},
+			},
+			{
+				BaseFeePerGas: assets.NewWeiI(100000),
+				Number:        3,
+				Hash:          utils.NewHash(),
+				Transactions:  []evmtypes.Transaction{},
+			},
+		}
+
+		gas.SetRollingBlockHistory(bhe, blocks)
+		bhe.Recalculate(testutils.Head(3))
+		gas.SimulateStart(t, bhe)
+		gas.SetInitialFetch(bhe, true)
+
+		fee, err := bhe.GetMaxDynamicFee(maxGasPrice)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "BlockHistoryEstimator: no value for latest block base fee or tip cap")
+		assert.Equal(t, gas.DynamicFee{}, fee)
+	})
+
+	t.Run("returns error when currentBaseFee is nil", func(t *testing.T) {
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+
+		// Create blocks with transactions but no BaseFeePerGas
+		blocks := []evmtypes.Block{
+			{
+				Number:       0,
+				Hash:         utils.NewHash(),
+				Transactions: dynamicFeeTransactionsFromTipCaps(5000, 6000, 7000),
+			},
+			{
+				Number:       1,
+				Hash:         utils.NewHash(),
+				Transactions: dynamicFeeTransactionsFromTipCaps(8000, 9000, 10000),
+			},
+			{
+				Number:       2,
+				Hash:         utils.NewHash(),
+				Transactions: dynamicFeeTransactionsFromTipCaps(11000, 12000, 13000),
+			},
+			{
+				Number:       3,
+				Hash:         utils.NewHash(),
+				Transactions: dynamicFeeTransactionsFromTipCaps(14000, 15000, 16000),
+			},
+		}
+
+		gas.SetRollingBlockHistory(bhe, blocks)
+		bhe.Recalculate(testutils.Head(3))
+		gas.SimulateStart(t, bhe)
+		gas.SetInitialFetch(bhe, true)
+
+		fee, err := bhe.GetMaxDynamicFee(maxGasPrice)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "BlockHistoryEstimator: no value for latest block base fee or tip cap")
+		assert.Equal(t, gas.DynamicFee{}, fee)
+	})
+
+	t.Run("returns max dynamic fee", func(t *testing.T) {
+		bhe := newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
+
+		// Create blocks with EIP-1559 transactions and base fees
+		blocks := []evmtypes.Block{
+			{
+				BaseFeePerGas: assets.NewWeiI(100000),
+				Number:        0,
+				Hash:          utils.NewHash(),
+				Transactions:  dynamicFeeTransactionsFromTipCaps(5000, 6000, 7000),
+			},
+			{
+				BaseFeePerGas: assets.NewWeiI(110000),
+				Number:        1,
+				Hash:          utils.NewHash(),
+				Transactions:  dynamicFeeTransactionsFromTipCaps(8000, 9000, 10000),
+			},
+			{
+				BaseFeePerGas: assets.NewWeiI(120000),
+				Number:        2,
+				Hash:          utils.NewHash(),
+				Transactions:  dynamicFeeTransactionsFromTipCaps(11000, 12000, 13000),
+			},
+			{
+				BaseFeePerGas: assets.NewWeiI(130000),
+				Number:        3,
+				Hash:          utils.NewHash(),
+				Transactions:  dynamicFeeTransactionsFromTipCaps(14000, 15000, 16000),
+			},
+		}
+
+		gas.SetRollingBlockHistory(bhe, blocks)
+		h := testutils.Head(3)
+		h.BaseFeePerGas = assets.NewWeiI(100000)
+		bhe.Recalculate(h)
+		gas.SimulateStart(t, bhe)
+		gas.SetInitialFetch(bhe, true)
+		bhe.OnNewLongestChain(t.Context(), h)
+
+		fee, err := bhe.GetMaxDynamicFee(maxGasPrice)
+		require.NoError(t, err)
+		require.NotNil(t, fee.GasFeeCap)
+		require.NotNil(t, fee.GasTipCap)
+
+		// Verify it matches the max percentile tip cap
+		expectedMaxPercentileTipCap := gas.GetMaxPercentileTipCap(bhe)
+		assert.Equal(t, expectedMaxPercentileTipCap, fee.GasTipCap)
+
+		// Verify fee cap is calculated correctly (base fee + buffer + tip cap, capped at maxGasPrice)
+		latestBaseFee := gas.GetLatestBaseFee(bhe)
+		require.NotNil(t, latestBaseFee)
+		assert.Greater(t, fee.GasFeeCap.Int64(), int64(0))
+		assert.LessOrEqual(t, fee.GasFeeCap.Int64(), maxGasPrice.Int64())
 	})
 }
 

--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -178,6 +178,12 @@ func (f *FeeHistoryEstimator) GetLegacyGas(ctx context.Context, _ []byte, gasLim
 	return
 }
 
+// GetMaxLegacyGas is not supported for FeeHistoryEstimator because eth_gasPrice fetches a single value gas price, so there is no way to increase the priority via this method.
+// If there is a need to support this, we can always return the result of GetLegacyGas but that wouldn't increase the priority.
+func (f *FeeHistoryEstimator) GetMaxLegacyGas(_ context.Context, _ []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, _ ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) {
+	return nil, 0, errors.New("max legacy gas is not supported for FeeHistoryEstimator")
+}
+
 // RefreshGasPrice will use eth_gasPrice to fetch and cache the latest gas price from the RPC.
 func (f *FeeHistoryEstimator) RefreshGasPrice() (*assets.Wei, error) {
 	ctx, cancel := f.stopCh.CtxWithTimeout(client.QueryTimeout)

--- a/pkg/gas/fee_history_estimator_test.go
+++ b/pkg/gas/fee_history_estimator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
@@ -281,6 +282,62 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, maxPrice, dynamicFee.GasFeeCap)
 		assert.Equal(t, maxPrice, dynamicFee.GasTipCap)
+	})
+}
+
+func TestFeeHistoryEstimatorGetMaxDynamicFee(t *testing.T) {
+	t.Parallel()
+
+	maxPrice := assets.NewWeiI(100)
+	chainID := testutils.FixtureChainID
+
+	t.Run("returns error when priorityFeeThreshold is not set", func(t *testing.T) {
+		cfg := gas.FeeHistoryEstimatorConfig{
+			BumpPercent:      20,
+			RewardPercentile: 60,
+			EIP1559:          true,
+		}
+
+		u := gas.NewFeeHistoryEstimator(logger.Test(t), nil, cfg, chainID, nil)
+		fee, err := u.GetMaxDynamicFee(maxPrice)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "priorityFeeThreshold not set")
+		assert.Equal(t, gas.DynamicFee{}, fee)
+	})
+
+	t.Run("returns max dynamic fee", func(t *testing.T) {
+		client := mocks.NewFeeHistoryEstimatorClient(t)
+		baseFee := big.NewInt(5)
+		marketMaxPriorityFeePerGas := big.NewInt(10)
+		connectivityMaxPriorityFeePerGas := big.NewInt(20)
+
+		feeHistoryResult := &ethereum.FeeHistory{
+			OldestBlock:  big.NewInt(1),
+			Reward:       [][]*big.Int{{marketMaxPriorityFeePerGas, connectivityMaxPriorityFeePerGas}}, // first one represents market price and second one connectivity price
+			BaseFee:      []*big.Int{baseFee, baseFee},
+			GasUsedRatio: nil,
+		}
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+
+		cfg := gas.FeeHistoryEstimatorConfig{
+			BumpPercent:      20,
+			RewardPercentile: 60,
+			EIP1559:          true,
+			BlockHistorySize: 2,
+		}
+
+		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
+		err := u.RefreshDynamicPrice()
+		require.NoError(t, err)
+
+		expectedPriorityFeeThreshold := assets.NewWei(connectivityMaxPriorityFeePerGas)
+		expectedNextBaseFee := assets.NewWei(baseFee)
+		expectedMaxFeeCap := expectedNextBaseFee.AddPercentage(gas.BaseFeeBufferPercentage).Add(expectedPriorityFeeThreshold)
+
+		fee, err := u.GetMaxDynamicFee(maxPrice)
+		require.NoError(t, err)
+		assert.Equal(t, expectedMaxFeeCap, fee.GasFeeCap)
+		assert.Equal(t, expectedPriorityFeeThreshold, fee.GasTipCap)
 	})
 }
 

--- a/pkg/gas/fixed_price_estimator.go
+++ b/pkg/gas/fixed_price_estimator.go
@@ -16,37 +16,23 @@ import (
 var _ EvmEstimator = (*fixedPriceEstimator)(nil)
 
 type fixedPriceEstimator struct {
-	config   fixedPriceEstimatorConfig
-	bhConfig fixedPriceEstimatorBlockHistoryConfig
-	lggr     logger.SugaredLogger
-	l1Oracle rollups.L1Oracle
+	config                    fixedPriceEstimatorConfig
+	EIP1559FeeCapBufferBlocks uint16
+	lggr                      logger.SugaredLogger
+	l1Oracle                  rollups.L1Oracle
 }
-type bumpConfig interface {
-	LimitMultiplier() float32
-	PriceMax() *assets.Wei
-	BumpPercent() uint16
-	BumpMin() *assets.Wei
-	TipCapDefault() *assets.Wei
-}
-
 type fixedPriceEstimatorConfig interface {
 	BumpThreshold() uint64
 	FeeCapDefault() *assets.Wei
 	PriceDefault() *assets.Wei
-	TipCapDefault() *assets.Wei
-	PriceMax() *assets.Wei
 	Mode() string
 	bumpConfig
 }
 
-type fixedPriceEstimatorBlockHistoryConfig interface {
-	EIP1559FeeCapBufferBlocks() uint16
-}
-
 // NewFixedPriceEstimator returns a new "FixedPrice" estimator which will
 // always use the config default values for gas prices and limits
-func NewFixedPriceEstimator(cfg fixedPriceEstimatorConfig, ethClient feeEstimatorClient, bhCfg fixedPriceEstimatorBlockHistoryConfig, lggr logger.Logger, l1Oracle rollups.L1Oracle) EvmEstimator {
-	return &fixedPriceEstimator{cfg, bhCfg, logger.Sugared(logger.Named(lggr, "FixedPriceEstimator")), l1Oracle}
+func NewFixedPriceEstimator(cfg fixedPriceEstimatorConfig, ethClient feeEstimatorClient, EIP1559FeeCapBufferBlocks uint16, lggr logger.Logger, l1Oracle rollups.L1Oracle) EvmEstimator {
+	return &fixedPriceEstimator{cfg, EIP1559FeeCapBufferBlocks, logger.Sugared(logger.Named(lggr, "FixedPriceEstimator")), l1Oracle}
 }
 
 func (f *fixedPriceEstimator) Start(context.Context) error {
@@ -90,6 +76,12 @@ func (f *fixedPriceEstimator) BumpLegacyGas(
 	return assets.NewWei(gasPrice), chainSpecificGasLimit, err
 }
 
+// GetMaxLegacyGas returns the result of GetLegacyGas. FixedPriceEstimator provides fixed gas prices, which generally indicates there is no priority queue or the network
+// expects fixed prices. Either way, fetching a standard gas estimation will have the same effect for transaction inclusion.
+func (f *fixedPriceEstimator) GetMaxLegacyGas(ctx context.Context, calldata []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) {
+	return f.GetLegacyGas(ctx, calldata, gasLimit, maxGasPriceWei, opts...)
+}
+
 func (f *fixedPriceEstimator) GetDynamicFee(_ context.Context, maxGasPriceWei *assets.Wei) (d DynamicFee, err error) {
 	gasTipCap := f.config.TipCapDefault()
 
@@ -120,7 +112,7 @@ func (f *fixedPriceEstimator) BumpDynamicFee(
 ) (bumped DynamicFee, err error) {
 	return BumpDynamicFeeOnly(
 		f.config,
-		f.bhConfig.EIP1559FeeCapBufferBlocks(),
+		f.EIP1559FeeCapBufferBlocks,
 		f.lggr,
 		f.config.TipCapDefault(),
 		nil,

--- a/pkg/gas/fixed_price_estimator_test.go
+++ b/pkg/gas/fixed_price_estimator_test.go
@@ -14,14 +14,6 @@ import (
 	rollupMocks "github.com/smartcontractkit/chainlink-evm/pkg/gas/rollups/mocks"
 )
 
-type blockHistoryConfig struct {
-	v uint16
-}
-
-func (b *blockHistoryConfig) EIP1559FeeCapBufferBlocks() uint16 {
-	return b.v
-}
-
 func Test_FixedPriceEstimator(t *testing.T) {
 	t.Parallel()
 	maxGasPrice := assets.NewWeiI(1000000)
@@ -30,7 +22,7 @@ func Test_FixedPriceEstimator(t *testing.T) {
 		config := &gas.MockGasEstimatorConfig{}
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		f := gas.NewFixedPriceEstimator(config, nil, &blockHistoryConfig{}, logger.Test(t), l1Oracle)
+		f := gas.NewFixedPriceEstimator(config, nil, 0, logger.Test(t), l1Oracle)
 
 		config.PriceDefaultF = assets.NewWeiI(42)
 		config.PriceMaxF = maxGasPrice
@@ -47,7 +39,7 @@ func Test_FixedPriceEstimator(t *testing.T) {
 		config.PriceMaxF = assets.NewWeiI(35)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		f := gas.NewFixedPriceEstimator(config, nil, &blockHistoryConfig{}, logger.Test(t), l1Oracle)
+		f := gas.NewFixedPriceEstimator(config, nil, 0, logger.Test(t), l1Oracle)
 
 		gasPrice, gasLimit, err := f.GetLegacyGas(tests.Context(t), nil, 100000, assets.NewWeiI(30))
 		require.NoError(t, err)
@@ -61,7 +53,7 @@ func Test_FixedPriceEstimator(t *testing.T) {
 		config.PriceMaxF = assets.NewWeiI(20)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		f := gas.NewFixedPriceEstimator(config, nil, &blockHistoryConfig{}, logger.Test(t), l1Oracle)
+		f := gas.NewFixedPriceEstimator(config, nil, 0, logger.Test(t), l1Oracle)
 		gasPrice, gasLimit, err := f.GetLegacyGas(tests.Context(t), nil, 100000, assets.NewWeiI(30))
 		require.NoError(t, err)
 		assert.Equal(t, 100000, int(gasLimit))
@@ -77,7 +69,7 @@ func Test_FixedPriceEstimator(t *testing.T) {
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
 		lggr := logger.TestSugared(t)
-		f := gas.NewFixedPriceEstimator(config, nil, &blockHistoryConfig{}, lggr, l1Oracle)
+		f := gas.NewFixedPriceEstimator(config, nil, 0, lggr, l1Oracle)
 
 		gasPrice, gasLimit, err := f.BumpLegacyGas(tests.Context(t), assets.NewWeiI(42), 100000, maxGasPrice, nil)
 		require.NoError(t, err)
@@ -98,7 +90,7 @@ func Test_FixedPriceEstimator(t *testing.T) {
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
 		lggr := logger.Test(t)
-		f := gas.NewFixedPriceEstimator(config, nil, &blockHistoryConfig{}, lggr, l1Oracle)
+		f := gas.NewFixedPriceEstimator(config, nil, 0, lggr, l1Oracle)
 
 		fee, err := f.GetDynamicFee(tests.Context(t), maxGasPrice)
 		require.NoError(t, err)
@@ -132,7 +124,7 @@ func Test_FixedPriceEstimator(t *testing.T) {
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
 		lggr := logger.TestSugared(t)
-		f := gas.NewFixedPriceEstimator(config, nil, &blockHistoryConfig{}, lggr, l1Oracle)
+		f := gas.NewFixedPriceEstimator(config, nil, 0, lggr, l1Oracle)
 
 		originalFee := gas.DynamicFee{GasFeeCap: assets.NewWeiI(100), GasTipCap: assets.NewWeiI(25)}
 		fee, err := f.BumpDynamicFee(tests.Context(t), originalFee, maxGasPrice, nil)

--- a/pkg/gas/helpers_test.go
+++ b/pkg/gas/helpers_test.go
@@ -83,6 +83,10 @@ func SimulateStart(t *testing.T, b *BlockHistoryEstimator) {
 	require.NoError(t, b.StartOnce("BlockHistoryEstimatorSimulatedStart", func() error { return nil }))
 }
 
+func SetInitialFetch(b *BlockHistoryEstimator, value bool) {
+	b.initialFetch.Store(value)
+}
+
 type MockBlockHistoryConfig struct {
 	BatchSizeF                 uint32
 	BlockDelayF                uint16

--- a/pkg/gas/mocks/evm_estimator.go
+++ b/pkg/gas/mocks/evm_estimator.go
@@ -400,6 +400,89 @@ func (_c *EvmEstimator_GetMaxDynamicFee_Call) RunAndReturn(run func(*assets.Wei)
 	return _c
 }
 
+// GetMaxLegacyGas provides a mock function with given fields: ctx, calldata, gasLimit, maxGasPriceWei, opts
+func (_m *EvmEstimator) GetMaxLegacyGas(ctx context.Context, calldata []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt) (*assets.Wei, uint64, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, calldata, gasLimit, maxGasPriceWei)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMaxLegacyGas")
+	}
+
+	var r0 *assets.Wei
+	var r1 uint64
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, uint64, *assets.Wei, ...fees.Opt) (*assets.Wei, uint64, error)); ok {
+		return rf(ctx, calldata, gasLimit, maxGasPriceWei, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, uint64, *assets.Wei, ...fees.Opt) *assets.Wei); ok {
+		r0 = rf(ctx, calldata, gasLimit, maxGasPriceWei, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*assets.Wei)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []byte, uint64, *assets.Wei, ...fees.Opt) uint64); ok {
+		r1 = rf(ctx, calldata, gasLimit, maxGasPriceWei, opts...)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, []byte, uint64, *assets.Wei, ...fees.Opt) error); ok {
+		r2 = rf(ctx, calldata, gasLimit, maxGasPriceWei, opts...)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// EvmEstimator_GetMaxLegacyGas_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMaxLegacyGas'
+type EvmEstimator_GetMaxLegacyGas_Call struct {
+	*mock.Call
+}
+
+// GetMaxLegacyGas is a helper method to define mock.On call
+//   - ctx context.Context
+//   - calldata []byte
+//   - gasLimit uint64
+//   - maxGasPriceWei *assets.Wei
+//   - opts ...fees.Opt
+func (_e *EvmEstimator_Expecter) GetMaxLegacyGas(ctx interface{}, calldata interface{}, gasLimit interface{}, maxGasPriceWei interface{}, opts ...interface{}) *EvmEstimator_GetMaxLegacyGas_Call {
+	return &EvmEstimator_GetMaxLegacyGas_Call{Call: _e.mock.On("GetMaxLegacyGas",
+		append([]interface{}{ctx, calldata, gasLimit, maxGasPriceWei}, opts...)...)}
+}
+
+func (_c *EvmEstimator_GetMaxLegacyGas_Call) Run(run func(ctx context.Context, calldata []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt)) *EvmEstimator_GetMaxLegacyGas_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]fees.Opt, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(fees.Opt)
+			}
+		}
+		run(args[0].(context.Context), args[1].([]byte), args[2].(uint64), args[3].(*assets.Wei), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *EvmEstimator_GetMaxLegacyGas_Call) Return(gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) *EvmEstimator_GetMaxLegacyGas_Call {
+	_c.Call.Return(gasPrice, chainSpecificGasLimit, err)
+	return _c
+}
+
+func (_c *EvmEstimator_GetMaxLegacyGas_Call) RunAndReturn(run func(context.Context, []byte, uint64, *assets.Wei, ...fees.Opt) (*assets.Wei, uint64, error)) *EvmEstimator_GetMaxLegacyGas_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // HealthReport provides a mock function with no fields
 func (_m *EvmEstimator) HealthReport() map[string]error {
 	ret := _m.Called()

--- a/pkg/gas/models.go
+++ b/pkg/gas/models.go
@@ -153,7 +153,7 @@ type EvmEstimator interface {
 	// GetLegacyGas Calculates initial gas fee for non-EIP1559 transaction
 	// maxGasPriceWei parameter is the highest possible gas fee cap that the function will return
 	GetLegacyGas(ctx context.Context, calldata []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error)
-	// GetMaxLegacyGas returns the maximum gas price allowed by the connectivity threshold to improve inclusion probability.
+	// GetMaxLegacyGas returns the maximum non-EIP1159 gas fee allowed by the connectivity threshold to improve inclusion probability.
 	GetMaxLegacyGas(ctx context.Context, calldata []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error)
 	// BumpLegacyGas Increases gas price and/or limit for non-EIP1559 transactions
 	// if the bumped gas fee is greater than maxGasPriceWei, the method returns an error

--- a/pkg/gas/models.go
+++ b/pkg/gas/models.go
@@ -39,6 +39,7 @@ type EvmFeeEstimator interface {
 
 	// GetMaxCost returns the total value = max price x fee units + transferred value
 	GetMaxCost(ctx context.Context, amount assets.Eth, calldata []byte, feeLimit uint64, maxFeePrice *assets.Wei, fromAddress, toAddress *common.Address, opts ...fees.Opt) (*big.Int, error)
+	// GetMaxFee returns the maximum fee allowed by the connectivity threshold to improve inclusion probability.
 	GetMaxFee(ctx context.Context, calldata []byte, feeLimit uint64, maxFeePrice *assets.Wei, fromAddress, toAddress *common.Address, opts ...fees.Opt) (fee EvmFee, estimatedFeeLimit uint64, err error)
 }
 
@@ -102,7 +103,7 @@ func NewEstimator(lggr logger.Logger, ethClient feeEstimatorClient, chaintype ch
 		}
 	case "FixedPrice":
 		newEstimator = func(l logger.Logger) EvmEstimator {
-			return NewFixedPriceEstimator(geCfg, ethClient, bh, lggr, l1Oracle)
+			return NewFixedPriceEstimator(geCfg, ethClient, bh.EIP1559FeeCapBufferBlocks(), lggr, l1Oracle)
 		}
 	case "L2Suggested", "SuggestedPrice":
 		newEstimator = func(l logger.Logger) EvmEstimator {
@@ -123,7 +124,7 @@ func NewEstimator(lggr logger.Logger, ethClient feeEstimatorClient, chaintype ch
 	default:
 		lggr.Warnf("GasEstimator: unrecognised mode '%s', falling back to FixedPriceEstimator", s)
 		newEstimator = func(l logger.Logger) EvmEstimator {
-			return NewFixedPriceEstimator(geCfg, ethClient, bh, lggr, l1Oracle)
+			return NewFixedPriceEstimator(geCfg, ethClient, bh.EIP1559FeeCapBufferBlocks(), lggr, l1Oracle)
 		}
 	}
 	return NewEvmFeeEstimator(lggr, newEstimator, df, geCfg, ethClient), nil
@@ -152,6 +153,8 @@ type EvmEstimator interface {
 	// GetLegacyGas Calculates initial gas fee for non-EIP1559 transaction
 	// maxGasPriceWei parameter is the highest possible gas fee cap that the function will return
 	GetLegacyGas(ctx context.Context, calldata []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error)
+	// GetMaxLegacyGas returns the maximum gas price allowed by the connectivity threshold to improve inclusion probability.
+	GetMaxLegacyGas(ctx context.Context, calldata []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error)
 	// BumpLegacyGas Increases gas price and/or limit for non-EIP1559 transactions
 	// if the bumped gas fee is greater than maxGasPriceWei, the method returns an error
 	// attempts must:
@@ -334,8 +337,7 @@ func (e *evmFeeEstimator) GetMaxFee(ctx context.Context, calldata []byte, feeLim
 		fee.GasTipCap = dynamicFee.GasTipCap
 		chainSpecificFeeLimit = feeLimit
 	} else {
-		// For legacy fees assume the chain doesn't have a mempool and there is no priority, so fetching the legacy gas will have the same effect.
-		fee.GasPrice, chainSpecificFeeLimit, err = e.EvmEstimator.GetLegacyGas(ctx, calldata, feeLimit, maxFeePrice, opts...)
+		fee.GasPrice, chainSpecificFeeLimit, err = e.EvmEstimator.GetMaxLegacyGas(ctx, calldata, feeLimit, maxFeePrice, opts...)
 		if err != nil {
 			return
 		}
@@ -448,6 +450,13 @@ type GasEstimatorConfig interface {
 	Mode() string
 	EstimateLimit() bool
 	SenderAddress() *evmtypes.EIP55Address
+}
+
+type bumpConfig interface {
+	PriceMax() *assets.Wei
+	BumpPercent() uint16
+	BumpMin() *assets.Wei
+	TipCapDefault() *assets.Wei
 }
 
 // BumpLegacyGasPriceOnly will increase the price
@@ -569,9 +578,4 @@ func maxBumpedFee(lggr logger.SugaredLogger, currentFeePrice, bumpedFeePrice, ma
 
 func getMaxGasPrice(userSpecifiedMax, maxGasPriceWei *assets.Wei) *assets.Wei {
 	return assets.NewWei(bigmath.Min(userSpecifiedMax.ToInt(), maxGasPriceWei.ToInt()))
-}
-
-func capGasPrice(calculatedGasPrice, userSpecifiedMax, maxGasPriceWei *assets.Wei) *assets.Wei {
-	maxGasPrice := fees.CalculateFee(calculatedGasPrice.ToInt(), userSpecifiedMax.ToInt(), maxGasPriceWei.ToInt())
-	return assets.NewWei(maxGasPrice)
 }

--- a/pkg/gas/suggested_price_estimator.go
+++ b/pkg/gas/suggested_price_estimator.go
@@ -2,13 +2,13 @@ package gas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	pkgerrors "github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -145,14 +145,14 @@ func (o *SuggestedPriceEstimator) forceRefresh(ctx context.Context) (err error) 
 	select {
 	case o.chForceRefetch <- ch:
 	case <-o.chStop:
-		return pkgerrors.New("estimator stopped")
+		return errors.New("estimator stopped")
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 	select {
 	case <-ch:
 	case <-o.chStop:
-		return pkgerrors.New("estimator stopped")
+		return errors.New("estimator stopped")
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -162,18 +162,22 @@ func (o *SuggestedPriceEstimator) forceRefresh(ctx context.Context) (err error) 
 func (o *SuggestedPriceEstimator) OnNewLongestChain(context.Context, *types.Head) {}
 
 func (*SuggestedPriceEstimator) GetDynamicFee(_ context.Context, _ *assets.Wei) (fee DynamicFee, err error) {
-	err = pkgerrors.New("dynamic fees are not implemented for this estimator")
+	err = errors.New("dynamic fees are not implemented for this estimator")
 	return
 }
 
 func (*SuggestedPriceEstimator) GetMaxDynamicFee(_ *assets.Wei) (fee DynamicFee, err error) {
-	err = pkgerrors.New("dynamic fees are not implemented for this estimator")
+	err = errors.New("dynamic fees are not implemented for this estimator")
 	return
 }
 
 func (*SuggestedPriceEstimator) BumpDynamicFee(_ context.Context, _ DynamicFee, _ *assets.Wei, _ []EvmPriorAttempt) (bumped DynamicFee, err error) {
-	err = pkgerrors.New("dynamic fees are not implemented for this estimator")
+	err = errors.New("dynamic fees are not implemented for this estimator")
 	return
+}
+
+func (o *SuggestedPriceEstimator) GetMaxLegacyGas(_ context.Context, _ []byte, _ uint64, maxGasPriceWei *assets.Wei, _ ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) {
+	return nil, 0, errors.New("GetMaxLegacyGas is not implemented for this estimator")
 }
 
 func (o *SuggestedPriceEstimator) GetLegacyGas(ctx context.Context, _ []byte, gasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) {
@@ -183,19 +187,19 @@ func (o *SuggestedPriceEstimator) GetLegacyGas(ctx context.Context, _ []byte, ga
 			err = o.forceRefresh(ctx)
 		}
 		if gasPrice = o.getGasPrice(); gasPrice == nil {
-			err = pkgerrors.New("failed to estimate gas; gas price not set")
+			err = errors.New("failed to estimate gas; gas price not set")
 			return
 		}
 		o.logger.Debugw("GetLegacyGas", "GasPrice", gasPrice, "GasLimit", gasLimit)
 	})
 	if !ok {
-		return nil, 0, pkgerrors.New("estimator is not started")
+		return nil, 0, errors.New("estimator is not started")
 	} else if err != nil {
 		return
 	}
 	// For L2 chains, submitting a transaction that is not priced high enough will cause the call to fail, so if the cap is lower than the RPC suggested gas price, this transaction cannot succeed
 	if gasPrice != nil && gasPrice.Cmp(maxGasPriceWei) > 0 {
-		return nil, 0, pkgerrors.Errorf("estimated gas price: %s is greater than the maximum gas price configured: %s", gasPrice.String(), maxGasPriceWei.String())
+		return nil, 0, fmt.Errorf("estimated gas price: %s is greater than the maximum gas price configured: %s", gasPrice.String(), maxGasPriceWei.String())
 	}
 	return
 }
@@ -215,18 +219,18 @@ func (o *SuggestedPriceEstimator) BumpLegacyGas(ctx context.Context, originalFee
 		}
 		err = o.forceRefresh(ctx)
 		if newGasPrice = o.getGasPrice(); newGasPrice == nil {
-			err = pkgerrors.New("failed to refresh and return gas; gas price not set")
+			err = errors.New("failed to refresh and return gas; gas price not set")
 			return
 		}
 		o.logger.Debugw("BumpLegacyGas", "GasPrice", newGasPrice, "GasLimit", feeLimit)
 	})
 	if !ok {
-		return nil, 0, pkgerrors.New("estimator is not started")
+		return nil, 0, errors.New("estimator is not started")
 	} else if err != nil {
 		return
 	}
 	if newGasPrice != nil && newGasPrice.Cmp(maxGasPriceWei) > 0 {
-		return nil, 0, pkgerrors.Errorf("estimated gas price: %s is greater than the maximum gas price configured: %s", newGasPrice.String(), maxGasPriceWei.String())
+		return nil, 0, fmt.Errorf("estimated gas price: %s is greater than the maximum gas price configured: %s", newGasPrice.String(), maxGasPriceWei.String())
 	}
 	// Add a buffer on top of the gas price returned by the RPC.
 	// Bump logic when using the suggested gas price from an RPC is realistically only needed when there is increased volatility in gas price.

--- a/pkg/txmgr/broadcaster_test.go
+++ b/pkg/txmgr/broadcaster_test.go
@@ -78,7 +78,7 @@ func NewTestEthBroadcaster(
 	ge := config.GasEstimator()
 
 	estimator := gas.NewEvmFeeEstimator(lggr, func(lggr logger.Logger) gas.EvmEstimator {
-		return gas.NewFixedPriceEstimator(config.GasEstimator(), nil, ge.BlockHistory(), lggr, nil)
+		return gas.NewFixedPriceEstimator(config.GasEstimator(), nil, ge.BlockHistory().EIP1559FeeCapBufferBlocks(), lggr, nil)
 	}, ge.EIP1559DynamicFees(), ge, ethClient)
 	txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), ge, keyStore, estimator)
 	metrics, err := txmgr.NewEVMTxmMetrics(ethClient.ConfiguredChainID().String())
@@ -1214,7 +1214,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 				t.Run("callback set by ctor", func(t *testing.T) {
 					evmcfg := configtest.NewChainScopedConfig(t, nil)
 					estimator := gas.NewEvmFeeEstimator(lggr, func(lggr logger.Logger) gas.EvmEstimator {
-						return gas.NewFixedPriceEstimator(evmcfg.EVM().GasEstimator(), nil, evmcfg.EVM().GasEstimator().BlockHistory(), lggr, nil)
+						return gas.NewFixedPriceEstimator(evmcfg.EVM().GasEstimator(), nil, evmcfg.EVM().GasEstimator().BlockHistory().EIP1559FeeCapBufferBlocks(), lggr, nil)
 					}, evmcfg.EVM().GasEstimator().EIP1559DynamicFees(), evmcfg.EVM().GasEstimator(), ethClient)
 					txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), evmcfg.EVM().GasEstimator(), ethKeyStore, estimator)
 					localNextNonce = getLocalNextNonce(t, nonceTracker, fromAddress)
@@ -1718,7 +1718,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_GasEstimationError(t *testing.T) 
 	nonceTracker := txmgr.NewNonceTracker(lggr, txStore, txmClient)
 	ge := config.EVM().GasEstimator()
 	estimator := gas.NewEvmFeeEstimator(lggr, func(lggr logger.Logger) gas.EvmEstimator {
-		return gas.NewFixedPriceEstimator(ge, nil, ge.BlockHistory(), lggr, nil)
+		return gas.NewFixedPriceEstimator(ge, nil, ge.BlockHistory().EIP1559FeeCapBufferBlocks(), lggr, nil)
 	}, ge.EIP1559DynamicFees(), ge, ethClient)
 	txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), ge, ethKeyStore, estimator)
 	metrics, err := txmgr.NewEVMTxmMetrics(ethClient.ConfiguredChainID().String())
@@ -1852,7 +1852,7 @@ func TestEthBroadcaster_SyncNonce(t *testing.T) {
 	kst := keys.NewChainStore(memKS, ethClient.ConfiguredChainID())
 
 	estimator := gas.NewEvmFeeEstimator(lggr, func(lggr logger.Logger) gas.EvmEstimator {
-		return gas.NewFixedPriceEstimator(evmcfg.EVM().GasEstimator(), nil, evmcfg.EVM().GasEstimator().BlockHistory(), lggr, nil)
+		return gas.NewFixedPriceEstimator(evmcfg.EVM().GasEstimator(), nil, evmcfg.EVM().GasEstimator().BlockHistory().EIP1559FeeCapBufferBlocks(), lggr, nil)
 	}, evmcfg.EVM().GasEstimator().EIP1559DynamicFees(), evmcfg.EVM().GasEstimator(), ethClient)
 	checkerFactory := &testCheckerFactory{}
 
@@ -1926,7 +1926,7 @@ func TestEthBroadcaster_HederaBroadcastValidation(t *testing.T) {
 	lggr, observed := logger.TestObserved(t, zapcore.DebugLevel)
 	ge := evmcfg.EVM().GasEstimator()
 	estimator := gas.NewEvmFeeEstimator(lggr, func(lggr logger.Logger) gas.EvmEstimator {
-		return gas.NewFixedPriceEstimator(evmcfg.EVM().GasEstimator(), nil, ge.BlockHistory(), lggr, nil)
+		return gas.NewFixedPriceEstimator(evmcfg.EVM().GasEstimator(), nil, ge.BlockHistory().EIP1559FeeCapBufferBlocks(), lggr, nil)
 	}, ge.EIP1559DynamicFees(), ge, ethClient)
 	txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), ge, ethKeyStore, estimator)
 	checkerFactory := &txmgr.CheckerFactory{Client: ethClient}

--- a/pkg/txmgr/confirmer_test.go
+++ b/pkg/txmgr/confirmer_test.go
@@ -1744,7 +1744,7 @@ func newEthConfirmer(t testing.TB, txStore txmgr.EvmTxStore, ethClient client.Cl
 	lggr := logger.Test(t)
 	ge := config.EVM().GasEstimator()
 	estimator := gas.NewEvmFeeEstimator(lggr, func(lggr logger.Logger) gas.EvmEstimator {
-		return gas.NewFixedPriceEstimator(ge, nil, ge.BlockHistory(), lggr, nil)
+		return gas.NewFixedPriceEstimator(ge, nil, ge.BlockHistory().EIP1559FeeCapBufferBlocks(), lggr, nil)
 	}, ge.EIP1559DynamicFees(), ge, ethClient)
 	txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), ge, ks, estimator)
 	stuckTxDetector := txmgr.NewStuckTxDetector(lggr, testutils.FixtureChainID, "", assets.NewWei(assets.NewEth(100).ToInt()), config.EVM().Transactions().AutoPurge(), estimator, txStore, ethClient)


### PR DESCRIPTION
For SVR purposes we had to add a `GetMaxFee` method to the general gas estimator interface. Due to the strict deadline we implemented the underlying `GetMaxDynamicFee` method but not the `GetMaxLegacyGas` where applicable. This PR implements that method, adds some tests for `GetMaxDynamicFee` and does a small clean up regarding configs and deprecated methods.