### PR TITLE
Lower max attempts flag if there are no in-flight and unstarted trans…

### DIFF
--- a/pkg/txm/txm.go
+++ b/pkg/txm/txm.go
@@ -372,6 +372,7 @@ func (t *Txm) BackfillTransactions(ctx context.Context, address common.Address) 
 	}
 	if unconfirmedCount == 0 {
 		t.lggr.Debugf("All transactions confirmed for address: %v", address)
+		t.Metrics.ReachedMaxAttempts(ctx, false)
 		return nil
 	}
 


### PR DESCRIPTION
This PR lowers the max attempts flag if there are no transactions left to process. This eliminates false positives.