### PR TITLE
Reduce interface scope to enable KMS

### DIFF
--- a/pkg/keys/v2/core_keystore.go
+++ b/pkg/keys/v2/core_keystore.go
@@ -15,7 +15,18 @@ type TxKeyCoreKeystore struct {
 		keystore.Reader
 		keystore.Signer
 	}
-	cache map[string]string
+	cache           map[string]string
+	allowedKeyNames []string
+}
+
+type Option func(*TxKeyCoreKeystore)
+
+// Filter key names for example if using KMS and only certain key names are accessible.
+// (may not have ListKeys permission)
+func WithAllowedKeyNames(names []string) Option {
+	return func(s *TxKeyCoreKeystore) {
+		s.allowedKeyNames = names
+	}
 }
 
 // NewTxKeyCoreKeystore creates a new CoreKeystore for transaction keys.
@@ -24,15 +35,20 @@ type TxKeyCoreKeystore struct {
 func NewTxKeyCoreKeystore(ks interface {
 	keystore.Reader
 	keystore.Signer
-}) *TxKeyCoreKeystore {
-	return &TxKeyCoreKeystore{
-		ks:    ks,
-		cache: make(map[string]string),
+}, options ...Option) *TxKeyCoreKeystore {
+	txKeyCoreKeystore := &TxKeyCoreKeystore{
+		ks:              ks,
+		cache:           make(map[string]string),
+		allowedKeyNames: []string{},
 	}
+	for _, opt := range options {
+		opt(txKeyCoreKeystore)
+	}
+	return txKeyCoreKeystore
 }
 
 func (s *TxKeyCoreKeystore) Accounts(ctx context.Context) ([]string, error) {
-	keys, err := GetTxKeys(ctx, s.ks, []string{})
+	keys, err := GetTxKeys(ctx, s.ks, s.allowedKeyNames)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +71,7 @@ func (s *TxKeyCoreKeystore) Sign(ctx context.Context, account string, data []byt
 		return resp.Signature, nil
 	}
 	// Otherwise do the first time lookup to find the key by address.
-	keys, err := GetTxKeys(ctx, s.ks, []string{})
+	keys, err := GetTxKeys(ctx, s.ks, s.allowedKeyNames)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/keys/v2/core_keystore.go
+++ b/pkg/keys/v2/core_keystore.go
@@ -11,14 +11,20 @@ import (
 var _ core.Keystore = &TxKeyCoreKeystore{}
 
 type TxKeyCoreKeystore struct {
-	ks    keystore.Keystore
+	ks interface {
+		keystore.Reader
+		keystore.Signer
+	}
 	cache map[string]string
 }
 
 // NewTxKeyCoreKeystore creates a new CoreKeystore for transaction keys.
 // This wrapper is required for using TxKeys with the txm
 // which requires address based lookups.
-func NewTxKeyCoreKeystore(ks keystore.Keystore) *TxKeyCoreKeystore {
+func NewTxKeyCoreKeystore(ks interface {
+	keystore.Reader
+	keystore.Signer
+}) *TxKeyCoreKeystore {
 	return &TxKeyCoreKeystore{
 		ks:    ks,
 		cache: make(map[string]string),

--- a/pkg/keys/v2/core_keystore.go
+++ b/pkg/keys/v2/core_keystore.go
@@ -47,8 +47,15 @@ func NewTxKeyCoreKeystore(ks interface {
 	return txKeyCoreKeystore
 }
 
+func (s *TxKeyCoreKeystore) getKeys(ctx context.Context) ([]*TxKey, error) {
+	if len(s.allowedKeyNames) != 0 {
+		return LoadTxKeys(ctx, s.ks, s.allowedKeyNames)
+	}
+	return GetTxKeys(ctx, s.ks, []string{})
+}
+
 func (s *TxKeyCoreKeystore) Accounts(ctx context.Context) ([]string, error) {
-	keys, err := GetTxKeys(ctx, s.ks, s.allowedKeyNames)
+	keys, err := s.getKeys(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +78,7 @@ func (s *TxKeyCoreKeystore) Sign(ctx context.Context, account string, data []byt
 		return resp.Signature, nil
 	}
 	// Otherwise do the first time lookup to find the key by address.
-	keys, err := GetTxKeys(ctx, s.ks, s.allowedKeyNames)
+	keys, err := s.getKeys(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/keys/v2/evm_tx.go
+++ b/pkg/keys/v2/evm_tx.go
@@ -4,7 +4,9 @@ package keys
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
@@ -159,6 +161,32 @@ func GetTxKeys(ctx context.Context, ks keystore.Keystore, names []string) ([]*Tx
 	}
 
 	// Note we rely on deterministic order of keys in the response
+	keys := make([]*TxKey, 0, len(resp.Keys))
+	for _, key := range resp.Keys {
+		publicKey, err := gethcrypto.UnmarshalPubkey(key.KeyInfo.PublicKey)
+		if err != nil {
+			return nil, err
+		}
+		addr := gethcrypto.PubkeyToAddress(*publicKey)
+		keys = append(keys, &TxKey{
+			ks:      ks,
+			keyPath: keystore.NewKeyPathFromString(key.KeyInfo.Name),
+			addr:    addr,
+		})
+	}
+	return keys, nil
+}
+
+// LoadTxKey loads a transaction key from a keystore directly by name.
+// Used for KMS-backed keystores where keys/key names are managed externally.
+func LoadTxKeys(ctx context.Context, ks keystore.Keystore, names []string) ([]*TxKey, error) {
+	resp, err := ks.GetKeys(ctx, keystore.GetKeysRequest{KeyNames: names})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Keys) != len(names) {
+		return nil, fmt.Errorf("some keys not found: %s", strings.Join(names, ", "))
+	}
 	keys := make([]*TxKey, 0, len(resp.Keys))
 	for _, key := range resp.Keys {
 		publicKey, err := gethcrypto.UnmarshalPubkey(key.KeyInfo.PublicKey)

--- a/pkg/keys/v2/evm_tx.go
+++ b/pkg/keys/v2/evm_tx.go
@@ -24,7 +24,10 @@ const (
 
 // TxKey represents an EVM transaction signing key.
 type TxKey struct {
-	ks      keystore.Keystore
+	ks interface {
+		keystore.Reader
+		keystore.Signer
+	}
 	keyPath keystore.KeyPath
 	addr    common.Address
 }
@@ -150,7 +153,10 @@ func CreateTxKey(ks keystore.Keystore, name string) (*TxKey, error) {
 }
 
 // GetTxKeys retrieves transaction keys by name.
-func GetTxKeys(ctx context.Context, ks keystore.Keystore, names []string) ([]*TxKey, error) {
+func GetTxKeys(ctx context.Context, ks interface {
+	keystore.Reader
+	keystore.Signer
+}, names []string) ([]*TxKey, error) {
 	fullNames := make([]string, 0, len(names))
 	for _, name := range names {
 		fullNames = append(fullNames, keystore.NewKeyPath(PrefixEVM, PrefixTxKeystore, name).String())
@@ -179,7 +185,10 @@ func GetTxKeys(ctx context.Context, ks keystore.Keystore, names []string) ([]*Tx
 
 // LoadTxKey loads a transaction key from a keystore directly by name.
 // Used for KMS-backed keystores where keys/key names are managed externally.
-func LoadTxKeys(ctx context.Context, ks keystore.Keystore, names []string) ([]*TxKey, error) {
+func LoadTxKeys(ctx context.Context, ks interface {
+	keystore.Reader
+	keystore.Signer
+}, names []string) ([]*TxKey, error) {
 	resp, err := ks.GetKeys(ctx, keystore.GetKeysRequest{KeyNames: names})
 	if err != nil {
 		return nil, err

--- a/pkg/keys/v2/evm_tx_test.go
+++ b/pkg/keys/v2/evm_tx_test.go
@@ -4,12 +4,24 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	commonks "github.com/smartcontractkit/chainlink-common/keystore"
 	evmks "github.com/smartcontractkit/chainlink-evm/pkg/keys/v2"
 	"github.com/stretchr/testify/require"
 )
+
+func setupBackend(t *testing.T, testKey common.Address) (*simulated.Backend, func() error) {
+	backend := simulated.NewBackend(types.GenesisAlloc{
+		testKey: {
+			Balance: big.NewInt(0).Mul(big.NewInt(10), big.NewInt(1e18)), // 10 ETH
+		},
+	}, simulated.WithBlockGasLimit(10e6))
+	return backend, func() error {
+		return backend.Close()
+	}
+}
 
 func TestTxKey(t *testing.T) {
 	storage := commonks.NewMemoryStorage()
@@ -21,14 +33,9 @@ func TestTxKey(t *testing.T) {
 	testKey2, err := evmks.CreateTxKey(ks, "test-tx-key-2")
 	require.NoError(t, err)
 
-	backend := simulated.NewBackend(types.GenesisAlloc{
-		testKey.Address(): {
-			Balance: big.NewInt(0).Mul(big.NewInt(10), big.NewInt(1e18)), // 10 ETH
-		},
-	}, simulated.WithBlockGasLimit(10e6))
-	defer func() {
-		require.NoError(t, backend.Close())
-	}()
+	backend, cleanup := setupBackend(t, testKey2.Address())
+	defer cleanup()
+
 	testTransaction := types.NewTransaction(
 		0,                       // Nonce
 		testKey2.Address(),      // To other key
@@ -70,4 +77,38 @@ func TestTxKey(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.ErrorIs(t, err, commonks.ErrKeyNotFound)
+}
+
+func TestLoadTxKeys(t *testing.T) {
+	storage := commonks.NewMemoryStorage()
+	ctx := t.Context()
+	ks, err := commonks.LoadKeystore(ctx, storage, "test-password", commonks.WithScryptParams(commonks.FastScryptParams))
+	require.NoError(t, err)
+	_, err = ks.CreateKeys(ctx, commonks.CreateKeysRequest{
+		Keys: []commonks.CreateKeyRequest{
+			{KeyName: "test-tx-key", KeyType: commonks.ECDSA_S256},
+			{KeyName: "test-tx-key-2", KeyType: commonks.ECDSA_S256},
+		},
+	})
+	require.NoError(t, err)
+	txKeys, err := evmks.LoadTxKeys(ctx, ks, []string{"test-tx-key", "test-tx-key-2"})
+	require.NoError(t, err)
+	require.Len(t, txKeys, 2)
+	require.Equal(t, "test-tx-key", txKeys[0].KeyPath().String())
+	require.Equal(t, "test-tx-key-2", txKeys[1].KeyPath().String())
+
+	// Ensure we can sign with a loaded key just as usual.
+	backend, cleanup := setupBackend(t, txKeys[1].Address())
+	defer cleanup()
+	resp, err := txKeys[1].SignTx(ctx, evmks.SignTxRequest{
+		ChainID: big.NewInt(1337),
+		Tx:      types.NewTransaction(0, txKeys[1].Address(), big.NewInt(1), 21000, big.NewInt(20000000000), nil),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Tx)
+	require.NoError(t, backend.Client().SendTransaction(ctx, resp.Tx))
+	backend.Commit()
+	receipt, err := backend.Client().TransactionReceipt(ctx, resp.Tx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 }

--- a/pkg/keys/v2/evm_tx_test.go
+++ b/pkg/keys/v2/evm_tx_test.go
@@ -33,7 +33,7 @@ func TestTxKey(t *testing.T) {
 	testKey2, err := evmks.CreateTxKey(ks, "test-tx-key-2")
 	require.NoError(t, err)
 
-	backend, cleanup := setupBackend(t, testKey2.Address())
+	backend, cleanup := setupBackend(t, testKey.Address())
 	defer cleanup()
 
 	testTransaction := types.NewTransaction(


### PR DESCRIPTION
The full keystore (with Admin which has write capabilities) isn't needed, we can reduce scope to readonly and that allows us to plug in KMS impls which can't have an Admin implementation.  

Note while technically a breaking change this won't break callers