### PR TITLE
Add virtual to authorized callers config

### DIFF
--- a/contracts/src/v0.8/shared/access/AuthorizedCallers.sol
+++ b/contracts/src/v0.8/shared/access/AuthorizedCallers.sol
@@ -43,7 +43,7 @@ contract AuthorizedCallers is Ownable2StepMsgSender {
   /// @param authorizedCallerArgs Callers to add and remove. Removals are performed first.
   function applyAuthorizedCallerUpdates(
     AuthorizedCallerArgs memory authorizedCallerArgs
-  ) external onlyOwner {
+  ) external virtual onlyOwner {
     _applyAuthorizedCallerUpdates(authorizedCallerArgs);
   }
 


### PR DESCRIPTION
virtual allows inheritors to customize authorizeCaller config behavior, e.g disallow caller list change in some scenarios