### PR TITLE
Potential fix for code scanning alert no. 71: Missing regular expression anchor

### DIFF
--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -706,7 +706,7 @@ var hyperliquid = ClientErrors{
 
 // Linkpool, Blockdaemon, and Chainstack all return "request timed out" if the log results are too large for them to process
 var defaultClient = ClientErrors{
-	TooManyResults: regexp.MustCompile(`request timed out|408 Request Timed Out$`),
+	TooManyResults: regexp.MustCompile(`(request timed out|408 Request Timed Out)$`),
 }
 
 // JSON-RPC error codes which can indicate a refusal of the server to process an eth_getLogs request because the result set is too large


### PR DESCRIPTION
Potential fix for [https://github.com/smartcontractkit/chainlink-evm/security/code-scanning/71](https://github.com/smartcontractkit/chainlink-evm/security/code-scanning/71)

In general, to fix misleading operator precedence with anchors in regular expressions that use alternation (`|`), wrap the alternatives in a non-capturing or capturing group and place the anchor outside the group (for example, `^(a|b)$` instead of `^a|b$`). This ensures all alternatives are consistently anchored.

For this specific case in `pkg/client/errors.go` line 709, we should group the two alternatives and apply the end-of-string anchor `$` to the whole group. That preserves the existing semantics of matching either `request timed out` or `408 Request Timed Out` while ensuring both must appear at the end of the string, consistent with how the second alternative is currently written. The minimal change is to update the pattern from ``request timed out|408 Request Timed Out$`` to ``(request timed out|408 Request Timed Out)$``. No imports or additional methods are needed; we only adjust the regex literal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
