### PR TITLE
Potential fix for code scanning alert no. 78: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,6 +2,9 @@ name: Build and Test
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build-test-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/smartcontractkit/chainlink-evm/security/code-scanning/78](https://github.com/smartcontractkit/chainlink-evm/security/code-scanning/78)

To fix the issue, we should explicitly restrict `GITHUB_TOKEN` permissions in this workflow. Since none of the jobs perform repository writes via the API or push commits, they can safely run with read‑only repository contents permissions. The recommended pattern is to add a `permissions:` block at the top level of the workflow so it applies to all jobs (`build-test-matrix`, `build-test`, and `check-tidy`), unless a job overrides it.

The single best fix is to add:

```yaml
permissions:
  contents: read
```

near the top of `.github/workflows/build-test.yml`, alongside `name:` and `on:`. This documents the intent and ensures the token stays limited even if organization defaults change. No other code or steps need to be modified, and no additional permissions (like `pull-requests: write`) are necessary based on the provided snippet.

Concretely:
- Edit `.github/workflows/build-test.yml`.
- Insert a top-level `permissions:` block after the `on:` declaration (line 3–4 area).
- Keep indentation consistent with YAML top-level keys.

No imports or additional methods are required; this is purely a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
