### PR TITLE
PLEX - 2452 - Add LogPoller health reporting to chain health aggregation

### DIFF
--- a/pkg/chains/legacyevm/chain.go
+++ b/pkg/chains/legacyevm/chain.go
@@ -416,6 +416,9 @@ func (c *chain) Ready() (merr error) {
 	if c.balanceMonitor != nil {
 		merr = multierr.Combine(merr, c.balanceMonitor.Ready())
 	}
+	if c.logPoller != logpoller.LogPollerDisabled {
+		merr = multierr.Combine(merr, c.logPoller.Ready())
+	}
 	return
 }
 
@@ -432,6 +435,10 @@ func (c *chain) HealthReport() map[string]error {
 
 	if c.balanceMonitor != nil {
 		services.CopyHealth(report, c.balanceMonitor.HealthReport())
+	}
+
+	if c.logPoller != logpoller.LogPollerDisabled {
+		services.CopyHealth(report, c.logPoller.HealthReport())
 	}
 
 	return report


### PR DESCRIPTION
### Summary
LogPoller's health status (finality violations, missing blocks) was not being surfaced to OTEL metrics because it was missing from the chain's HealthReport() aggregation. Added LogPoller to HealthReport() and Ready() methods to fix this wiring issue.