### PR TITLE
Remove heads ID column

### DIFF
--- a/pkg/client/sub_forwarder_test.go
+++ b/pkg/client/sub_forwarder_test.go
@@ -104,9 +104,7 @@ func TestChainIDSubForwarder(t *testing.T) {
 		err := forwarder.start(sub, nil)
 		assert.NoError(t, err)
 
-		head := &evmtypes.Head{
-			ID: 1,
-		}
+		head := &evmtypes.Head{}
 		forwarder.srcCh <- head
 		receivedHead := <-ch
 		assert.Equal(t, head, receivedHead)
@@ -131,9 +129,7 @@ func TestSubscriptionForwarder(t *testing.T) {
 		mockedSub := NewMockSubscription()
 		require.NoError(t, forwarder.start(mockedSub, nil))
 
-		head := &evmtypes.Head{
-			ID: 1,
-		}
+		head := &evmtypes.Head{}
 		forwarder.srcCh <- head
 		err := <-forwarder.Err()
 		require.ErrorIs(t, err, expectedErr)

--- a/pkg/heads/orm.go
+++ b/pkg/heads/orm.go
@@ -155,9 +155,11 @@ func (orm *DbORM) FirstHead(ctx context.Context) (*evmtypes.Head, error) {
 	head := new(evmtypes.Head)
 	err := orm.ds.GetContext(ctx, head, headsSelectBase+` WHERE evm_chain_id = $1 ORDER BY number ASC LIMIT 1`, orm.chainID)
 	if err != nil {
+		if pkgerrors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
 		return nil, err
 	}
-
 	return head, nil
 }
 

--- a/pkg/heads/orm.go
+++ b/pkg/heads/orm.go
@@ -30,6 +30,8 @@ type ORM interface {
 
 var _ ORM = &DbORM{}
 
+var headsSelectBase = `SELECT "hash", "number", "parent_hash", "created_at", "timestamp", "l1_block_number", "evm_chain_id", "base_fee_per_gas" FROM evm.heads`
+
 type DbORM struct {
 	chainID                sqlutil.Big
 	ds                     sqlutil.DataSource
@@ -126,7 +128,7 @@ func (orm *DbORM) TrimOldHeads(ctx context.Context, minBlockNumber int64) (err e
 
 func (orm *DbORM) LatestHead(ctx context.Context) (head *evmtypes.Head, err error) {
 	head = new(evmtypes.Head)
-	err = orm.ds.GetContext(ctx, head, `SELECT * FROM evm.heads WHERE evm_chain_id = $1 ORDER BY number DESC, created_at DESC, id DESC LIMIT 1`, orm.chainID)
+	err = orm.ds.GetContext(ctx, head, headsSelectBase+` WHERE evm_chain_id = $1 ORDER BY number DESC LIMIT 1`, orm.chainID)
 	if pkgerrors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -135,18 +137,28 @@ func (orm *DbORM) LatestHead(ctx context.Context) (head *evmtypes.Head, err erro
 }
 
 func (orm *DbORM) LatestHeads(ctx context.Context, minBlockNumer int64) (heads []*evmtypes.Head, err error) {
-	err = orm.ds.SelectContext(ctx, &heads, `SELECT * FROM evm.heads WHERE evm_chain_id = $1 AND number >= $2 ORDER BY number DESC, created_at DESC, id DESC`, orm.chainID, minBlockNumer)
+	err = orm.ds.SelectContext(ctx, &heads, headsSelectBase+` WHERE evm_chain_id = $1 AND number >= $2 ORDER BY number DESC`, orm.chainID, minBlockNumer)
 	err = pkgerrors.Wrap(err, "LatestHeads failed")
 	return
 }
 
 func (orm *DbORM) HeadByHash(ctx context.Context, hash common.Hash) (head *evmtypes.Head, err error) {
 	head = new(evmtypes.Head)
-	err = orm.ds.GetContext(ctx, head, `SELECT * FROM evm.heads WHERE evm_chain_id = $1 AND hash = $2`, orm.chainID, hash)
+	err = orm.ds.GetContext(ctx, head, headsSelectBase+` WHERE evm_chain_id = $1 AND hash = $2`, orm.chainID, hash)
 	if pkgerrors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	return head, err
+}
+
+func (orm *DbORM) FirstHead(ctx context.Context) (*evmtypes.Head, error) {
+	head := new(evmtypes.Head)
+	err := orm.ds.GetContext(ctx, head, headsSelectBase+` WHERE evm_chain_id = $1 ORDER BY number ASC LIMIT 1`, orm.chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	return head, nil
 }
 
 type nullORM struct{}

--- a/pkg/heads/tracker_test.go
+++ b/pkg/heads/tracker_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/jmoiron/sqlx"
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -42,14 +41,6 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 )
-
-func firstHead(t *testing.T, db *sqlx.DB) *evmtypes.Head {
-	h := new(evmtypes.Head)
-	if err := db.Get(h, `SELECT * FROM evm.heads ORDER BY number ASC LIMIT 1`); err != nil {
-		t.Fatal(err)
-	}
-	return h
-}
 
 func TestHeadTracker_New(t *testing.T) {
 	t.Parallel()
@@ -106,7 +97,8 @@ func TestHeadTracker_MarkFinalized_MarksAndTrimsTable(t *testing.T) {
 	require.NoError(t, ht.headSaver.MarkFinalized(tests.Context(t), latest))
 	assert.Equal(t, big.NewInt(201), ht.headSaver.LatestChain().ToInt())
 
-	firstHead := firstHead(t, db)
+	firstHead, err := orm.FirstHead(t.Context())
+	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(101), firstHead.ToInt())
 
 	lastHead, err := orm.LatestHead(tests.Context(t))

--- a/pkg/types/models.go
+++ b/pkg/types/models.go
@@ -35,7 +35,6 @@ type Header Head
 
 // Head represents a BlockNumber, BlockHash.
 type Head struct {
-	ID               uint64
 	Hash             common.Hash
 	Number           int64
 	L1BlockNumber    sql.NullInt64


### PR DESCRIPTION
EVM Heads contains a serial primary key that is not used, but, in some cases, consumes around 9GB of disk space.
Requires: https://github.com/smartcontractkit/chainlink/pull/21353
Ticket: https://smartcontract-it.atlassian.net/browse/PLEX-2402
