### PR TITLE
chore(ci): use apidiff-go v2

### DIFF
--- a/.github/workflows/api-diff.yml
+++ b/.github/workflows/api-diff.yml
@@ -6,12 +6,43 @@ on:
 permissions: {}
 
 jobs:
-  root-module:
-    name: Root Module
+  changed-modules:
+    name: Determine Changed Modules
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      modules-json: ${{ steps.changed-modules.outputs.modules-json }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Changed modules
+        id: changed-modules
+        uses: smartcontractkit/.github/actions/changed-modules-go@changed-modules-go/v1
+        with:
+          file-patterns: |
+            **/*.go
+            **/go.mod
+            **/go.sum
+          module-patterns: |
+            **
+
+  analyze-api-changes:
+    if: ${{ needs.changed-modules.outputs.modules-json != '[]' }}
+    name: Analyze (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    needs: changed-modules
     permissions:
       pull-requests: write
       contents: read
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.changed-modules.outputs.modules-json) }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v6
@@ -21,12 +52,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version-file: ${{ matrix.module }}/go.mod
           cache: false
 
-      - uses: smartcontractkit/.github/actions/apidiff-go@apidiff-go/v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - uses: smartcontractkit/.github/actions/apidiff-go@apidiff-go/v2
         with:
-          go-mod-paths: "./"
-          enforce-compatible: "false" # dont fail on breaking changes
+          module-directory: ${{ matrix.module }}
+          enforce-compatible: false
+          post-comment: true


### PR DESCRIPTION
### Changes

* Updates `apidiff-go` to v2
* Use `changed-modules-go` to conditionally run against all modified modules in the repository

