### PR TITLE
INC-2328 Add supportsDualBroadcast to txmv2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,6 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
-	github.com/smartcontractkit/chainlink-framework v0.0.0-20260312132640-34fd167e51e5 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b // indirect
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260205130626-db2a2aab956b // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/smartcontractkit/chainlink-data-streams v0.1.12-0.20260227110503-42b236799872
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022073203-7d8ae8cf67c1
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563
-	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260312132640-34fd167e51e5
+	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260317132927-e8bc2c7b01f1
 	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20251020150604-8ab84f7bad1a
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260217043601-5cc966896c4f

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,7 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
+	github.com/smartcontractkit/chainlink-framework v0.0.0-20260312132640-34fd167e51e5 // indirect
 	github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20251002192024-d2ad9222409b // indirect
 	github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260205130626-db2a2aab956b // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/smartcontractkit/chainlink-data-streams v0.1.12-0.20260227110503-42b236799872
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022073203-7d8ae8cf67c1
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563
-	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15
+	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260312132640-34fd167e51e5
 	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20251020150604-8ab84f7bad1a
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260217043601-5cc966896c4f

--- a/go.sum
+++ b/go.sum
@@ -658,14 +658,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.12-0.20260227110503-42b2
 github.com/smartcontractkit/chainlink-data-streams v0.1.12-0.20260227110503-42b236799872/go.mod h1:5jROIH/4cgHBQn875A+E2DCqvkBtrkHs+ciedcGTjNI=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022073203-7d8ae8cf67c1 h1:NTODgwAil7BLoijS7y6KnEuNbQ9v60VUhIR9FcAzIhg=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022073203-7d8ae8cf67c1/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
-github.com/smartcontractkit/chainlink-framework v0.0.0-20260312132640-34fd167e51e5 h1:CBL6mX/lsJ7MJVBufQl1MqxGHGuAaiicNgSCj0A3cWs=
-github.com/smartcontractkit/chainlink-framework v0.0.0-20260312132640-34fd167e51e5/go.mod h1:fFupTKernSf+WA5skA3ULEA5WQhmOXFfVOOEFU/4LiY=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 h1:ACpDbAxG4fa4sA83dbtYcrnlpE/y7thNIZfHxTv2ZLs=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563/go.mod h1:jP5mrOLFEYZZkl7EiCHRRIMSSHCQsYypm1OZSus//iI=
-github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15 h1:Mf+IRvrXutcKAKpuOxq5Ae+AAw4Z5vc66q1xI7qimZQ=
-github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
-github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260312132640-34fd167e51e5 h1:pcRTX0u7DaL9iK9LzQhNQlR8lCmiYj5f+KDGUhauYmM=
-github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260312132640-34fd167e51e5/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260317132927-e8bc2c7b01f1 h1:aUdjMnHpriMkEwsgeqQ/ZuNBjrWw6c46HG57TuPPEbE=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260317132927-e8bc2c7b01f1/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
 github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20251020150604-8ab84f7bad1a h1:pr0VFI7AWlDVJBEkcvzXWd97V8w8QMNjRdfPVa/IQLk=

--- a/go.sum
+++ b/go.sum
@@ -658,6 +658,8 @@ github.com/smartcontractkit/chainlink-data-streams v0.1.12-0.20260227110503-42b2
 github.com/smartcontractkit/chainlink-data-streams v0.1.12-0.20260227110503-42b236799872/go.mod h1:5jROIH/4cgHBQn875A+E2DCqvkBtrkHs+ciedcGTjNI=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022073203-7d8ae8cf67c1 h1:NTODgwAil7BLoijS7y6KnEuNbQ9v60VUhIR9FcAzIhg=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022073203-7d8ae8cf67c1/go.mod h1:oyfOm4k0uqmgZIfxk1elI/59B02shbbJQiiUdPdbMgI=
+github.com/smartcontractkit/chainlink-framework v0.0.0-20260312132640-34fd167e51e5 h1:CBL6mX/lsJ7MJVBufQl1MqxGHGuAaiicNgSCj0A3cWs=
+github.com/smartcontractkit/chainlink-framework v0.0.0-20260312132640-34fd167e51e5/go.mod h1:fFupTKernSf+WA5skA3ULEA5WQhmOXFfVOOEFU/4LiY=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563 h1:ACpDbAxG4fa4sA83dbtYcrnlpE/y7thNIZfHxTv2ZLs=
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563/go.mod h1:jP5mrOLFEYZZkl7EiCHRRIMSSHCQsYypm1OZSus//iI=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15 h1:Mf+IRvrXutcKAKpuOxq5Ae+AAw4Z5vc66q1xI7qimZQ=

--- a/go.sum
+++ b/go.sum
@@ -666,6 +666,8 @@ github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260312132640-34fd167e51e5 h1:pcRTX0u7DaL9iK9LzQhNQlR8lCmiYj5f+KDGUhauYmM=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260312132640-34fd167e51e5/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
+github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260317132927-e8bc2c7b01f1 h1:aUdjMnHpriMkEwsgeqQ/ZuNBjrWw6c46HG57TuPPEbE=
+github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260317132927-e8bc2c7b01f1/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
 github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20251020150604-8ab84f7bad1a h1:pr0VFI7AWlDVJBEkcvzXWd97V8w8QMNjRdfPVa/IQLk=
 github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20251020150604-8ab84f7bad1a/go.mod h1:jo+cUqNcHwN8IF7SInQNXDZ8qzBsyMpnLdYbDswviFc=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942 h1:T/eCDsUI8EJT4n5zSP4w1mz4RHH+ap8qieA17QYfBhk=

--- a/go.sum
+++ b/go.sum
@@ -664,6 +664,8 @@ github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-202508181755
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563/go.mod h1:jP5mrOLFEYZZkl7EiCHRRIMSSHCQsYypm1OZSus//iI=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15 h1:Mf+IRvrXutcKAKpuOxq5Ae+AAw4Z5vc66q1xI7qimZQ=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20251210101658-1c5c8e4c4f15/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
+github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260312132640-34fd167e51e5 h1:pcRTX0u7DaL9iK9LzQhNQlR8lCmiYj5f+KDGUhauYmM=
+github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260312132640-34fd167e51e5/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
 github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20251020150604-8ab84f7bad1a h1:pr0VFI7AWlDVJBEkcvzXWd97V8w8QMNjRdfPVa/IQLk=
 github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20251020150604-8ab84f7bad1a/go.mod h1:jo+cUqNcHwN8IF7SInQNXDZ8qzBsyMpnLdYbDswviFc=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20251021173435-e86785845942 h1:T/eCDsUI8EJT4n5zSP4w1mz4RHH+ap8qieA17QYfBhk=

--- a/pkg/chains/legacyevm/evm_txm.go
+++ b/pkg/chains/legacyevm/evm_txm.go
@@ -48,13 +48,17 @@ func newEvmTxm(
 
 	if opts.GenTxManager == nil {
 		var txmv2 txmgr.TxManager
-		if cfg.Transactions().TransactionManagerV2().Enabled() {
+		txV2Cfg := cfg.Transactions().TransactionManagerV2()
+		dualBroadcastEnabled := txV2Cfg.Enabled() &&
+			txV2Cfg.DualBroadcast() != nil && *txV2Cfg.DualBroadcast() &&
+			txV2Cfg.CustomURL() != nil
+		if txV2Cfg.Enabled() {
 			txmv2, err = txmgr.NewTxmV2(
 				ds,
 				cfg,
 				txmgr.NewEvmTxmFeeConfig(cfg.GasEstimator()),
 				cfg.Transactions(),
-				cfg.Transactions().TransactionManagerV2(),
+				txV2Cfg,
 				client,
 				lggr,
 				logPoller,
@@ -62,7 +66,7 @@ func newEvmTxm(
 				estimator,
 				cfg.GasEstimator(),
 			)
-			if cfg.Transactions().TransactionManagerV2().DualBroadcast() == nil || !*cfg.Transactions().TransactionManagerV2().DualBroadcast() {
+			if !dualBroadcastEnabled {
 				return txmv2, err
 			}
 		}
@@ -80,7 +84,8 @@ func newEvmTxm(
 			opts.KeyStore,
 			estimator,
 			headTracker,
-			txmv2)
+			txmv2,
+			dualBroadcastEnabled)
 	} else {
 		txm = opts.GenTxManager(chainID)
 	}

--- a/pkg/chains/legacyevm/evm_txm.go
+++ b/pkg/chains/legacyevm/evm_txm.go
@@ -66,8 +66,12 @@ func newEvmTxm(
 				estimator,
 				cfg.GasEstimator(),
 			)
+			if err != nil {
+				return nil, err
+			}
+
 			if !dualBroadcastEnabled {
-				return txmv2, err
+				return txmv2, nil
 			}
 		}
 		txm, err = txmgr.NewTxm(

--- a/pkg/chains/legacyevm/evm_txm.go
+++ b/pkg/chains/legacyevm/evm_txm.go
@@ -58,7 +58,7 @@ func newEvmTxm(
 				cfg,
 				txmgr.NewEvmTxmFeeConfig(cfg.GasEstimator()),
 				cfg.Transactions(),
-				cfg.Transactions().TransactionManagerV2(),
+				txV2Cfg,
 				client,
 				lggr,
 				logPoller,

--- a/pkg/chains/legacyevm/evm_txm.go
+++ b/pkg/chains/legacyevm/evm_txm.go
@@ -49,16 +49,16 @@ func newEvmTxm(
 	if opts.GenTxManager == nil {
 		var txmv2 txmgr.TxManager
 		txV2Cfg := cfg.Transactions().TransactionManagerV2()
-		dualBroadcastEnabled := txV2Cfg.Enabled() &&
-			txV2Cfg.DualBroadcast() != nil && *txV2Cfg.DualBroadcast() &&
-			txV2Cfg.CustomURL() != nil
+		dualBroadcastEnabled := txV2Cfg.Enabled() && txV2Cfg.DualBroadcast() != nil &&
+			*txV2Cfg.DualBroadcast() && txV2Cfg.CustomURL() != nil
+
 		if txV2Cfg.Enabled() {
 			txmv2, err = txmgr.NewTxmV2(
 				ds,
 				cfg,
 				txmgr.NewEvmTxmFeeConfig(cfg.GasEstimator()),
 				cfg.Transactions(),
-				txV2Cfg,
+				cfg.Transactions().TransactionManagerV2(),
 				client,
 				lggr,
 				logPoller,

--- a/pkg/transmitter/ocr/transmitter.go
+++ b/pkg/transmitter/ocr/transmitter.go
@@ -104,7 +104,7 @@ func NewOCR2FeedsTransmitter(
 
 	if dualTransmissionConfig != nil {
 		if keyHasLock(ks, dualTransmissionConfig.TransmitterAddress, keys.TXMv1) {
-			return nil, fmt.Errorf("key %s is used as a primary transmitter in another job. primary and secondary transmitters cannot be mixed", effectiveTransmitterAddress.String())
+			return nil, fmt.Errorf("key %s is used as a primary transmitter in another job. primary and secondary transmitters cannot be mixed", dualTransmissionConfig.TransmitterAddress.String())
 		}
 		if !txm.SupportsDualBroadcast() {
 			return nil, fmt.Errorf("job uses a secondary EOA (%s) for dual transmission but txm does not have DualBroadcast enabled, can't run this job", dualTransmissionConfig.TransmitterAddress.String())

--- a/pkg/transmitter/ocr/transmitter.go
+++ b/pkg/transmitter/ocr/transmitter.go
@@ -107,7 +107,7 @@ func NewOCR2FeedsTransmitter(
 			return nil, fmt.Errorf("key %s is used as a primary transmitter in another job. primary and secondary transmitters cannot be mixed", effectiveTransmitterAddress.String())
 		}
 		if !txm.SupportsDualBroadcast() {
-			return nil, fmt.Errorf("job uses a secondary EOA (%s) for dual transmission but TransactionManagerV2 does not have DualBroadcast enabled; secondary transactions would be sent to the public mempool. Enable TransactionManagerV2 with DualBroadcast=true in the node config", dualTransmissionConfig.TransmitterAddress.String())
+			return nil, fmt.Errorf("job uses a secondary EOA (%s) for dual transmission but txm does not have DualBroadcast enabled, can't run this job", dualTransmissionConfig.TransmitterAddress.String())
 		}
 		return &ocr2FeedsDualTransmission{
 			ocr2Aggregator:                     ocr2Aggregator,

--- a/pkg/transmitter/ocr/transmitter.go
+++ b/pkg/transmitter/ocr/transmitter.go
@@ -71,6 +71,7 @@ func NewTransmitter(
 type txManagerOCR2 interface {
 	CreateTransaction(ctx context.Context, txRequest txmgr.TxRequest) (tx txmgr.Tx, err error)
 	GetForwarderForEOAOCR2Feeds(ctx context.Context, eoa, ocr2AggregatorID common.Address) (forwarder common.Address, err error)
+	SupportsDualBroadcast() bool
 }
 
 type ocr2FeedsTransmitter struct {
@@ -104,6 +105,9 @@ func NewOCR2FeedsTransmitter(
 	if dualTransmissionConfig != nil {
 		if keyHasLock(ks, dualTransmissionConfig.TransmitterAddress, keys.TXMv1) {
 			return nil, fmt.Errorf("key %s is used as a primary transmitter in another job. primary and secondary transmitters cannot be mixed", effectiveTransmitterAddress.String())
+		}
+		if !txm.SupportsDualBroadcast() {
+			return nil, fmt.Errorf("job uses a secondary EOA (%s) for dual transmission but TransactionManagerV2 does not have DualBroadcast enabled; secondary transactions would be sent to the public mempool. Enable TransactionManagerV2 with DualBroadcast=true in the node config", dualTransmissionConfig.TransmitterAddress.String())
 		}
 		return &ocr2FeedsDualTransmission{
 			ocr2Aggregator:                     ocr2Aggregator,

--- a/pkg/transmitter/ocr/transmitter_test.go
+++ b/pkg/transmitter/ocr/transmitter_test.go
@@ -256,5 +256,5 @@ func Test_DualTransmitter_DualBroadcastNotEnabled_ReturnsError(t *testing.T) {
 		keys.NewStore(memoryKeystore),
 		dualTransmissionConfig,
 	)
-	require.ErrorContains(t, err, "TransactionManagerV2 does not have DualBroadcast enabled")
+	require.ErrorContains(t, err, "txm does not have DualBroadcast enabled")
 }

--- a/pkg/transmitter/ocr/transmitter_test.go
+++ b/pkg/transmitter/ocr/transmitter_test.go
@@ -180,6 +180,8 @@ func Test_DualTransmitter(t *testing.T) {
 		},
 	}
 
+	txm.On("SupportsDualBroadcast").Return(true)
+
 	transmitter, err := ocr.NewOCR2FeedsTransmitter(
 		txm,
 		[]common.Address{fromAddress},
@@ -222,4 +224,37 @@ func Test_DualTransmitter(t *testing.T) {
 
 	require.True(t, primaryTxConfirmed)
 	require.True(t, secondaryTxConfirmed)
+}
+
+func Test_DualTransmitter_DualBroadcastNotEnabled_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	memoryKeystore := keystest.NewMemoryChainStore()
+	fromAddress := memoryKeystore.MustCreate(t)
+	secondaryFromAddress := memoryKeystore.MustCreate(t)
+
+	contractAddress := utils.RandomAddress()
+	secondaryContractAddress := utils.RandomAddress()
+
+	txm := mocks.NewMockEvmTxManager(t)
+	txm.On("SupportsDualBroadcast").Return(false)
+
+	strategy := newMockTxStrategy(t)
+	dualTransmissionConfig := &config.DualTransmissionConfig{
+		ContractAddress:    secondaryContractAddress,
+		TransmitterAddress: secondaryFromAddress,
+	}
+
+	_, err := ocr.NewOCR2FeedsTransmitter(
+		txm,
+		[]common.Address{fromAddress},
+		contractAddress,
+		uint64(1000),
+		fromAddress,
+		strategy,
+		txmgr.TransmitCheckerSpec{},
+		keys.NewStore(memoryKeystore),
+		dualTransmissionConfig,
+	)
+	require.ErrorContains(t, err, "TransactionManagerV2 does not have DualBroadcast enabled")
 }

--- a/pkg/txm/orchestrator.go
+++ b/pkg/txm/orchestrator.go
@@ -49,15 +49,14 @@ type Orchestrator[
 	HEAD chains.Head[BLOCK_HASH],
 ] struct {
 	services.StateMachine
-	lggr                 logger.SugaredLogger
-	chainID              *big.Int
-	txm                  *Txm
-	txStore              OrchestratorTxStore
-	fwdMgr               *forwarders.FwdMgr
-	keystore             keys.Addresses
-	attemptBuilder       OrchestratorAttemptBuilder[BLOCK_HASH, HEAD]
-	resumeCallback       txmgr.ResumeCallback
-	dualBroadcastEnabled bool
+	lggr           logger.SugaredLogger
+	chainID        *big.Int
+	txm            *Txm
+	txStore        OrchestratorTxStore
+	fwdMgr         *forwarders.FwdMgr
+	keystore       keys.Addresses
+	attemptBuilder OrchestratorAttemptBuilder[BLOCK_HASH, HEAD]
+	resumeCallback txmgr.ResumeCallback
 }
 
 func NewTxmOrchestrator[BLOCK_HASH chains.Hashable, HEAD chains.Head[BLOCK_HASH]](
@@ -80,18 +79,11 @@ func NewTxmOrchestrator[BLOCK_HASH chains.Hashable, HEAD chains.Head[BLOCK_HASH]
 	}
 }
 
-// WithDualBroadcast marks the orchestrator as having a dual-broadcast client wired. When true,
-// jobs that use a secondary EOA (DualTransmission) are allowed to start.
-func (o *Orchestrator[BLOCK_HASH, HEAD]) WithDualBroadcast() *Orchestrator[BLOCK_HASH, HEAD] {
-	o.dualBroadcastEnabled = true
-	return o
-}
-
-// SupportsDualBroadcast returns true when the orchestrator was built with a dual-broadcast client,
-// meaning secondary (DualBroadcast) transactions will be routed to the private relay rather than
-// the public mempool.
+// SupportsDualBroadcast always returns false for the Orchestrator (TXMv2). When dual-broadcast is
+// enabled, the Orchestrator is wrapped by the legacy Txm, which is the TxManager exposed to
+// callers; that wrapper carries the dualBroadcastEnabled flag derived from the node config.
 func (o *Orchestrator[BLOCK_HASH, HEAD]) SupportsDualBroadcast() bool {
-	return o.dualBroadcastEnabled
+	return false
 }
 
 func (o *Orchestrator[BLOCK_HASH, HEAD]) Start(ctx context.Context) error {

--- a/pkg/txm/orchestrator.go
+++ b/pkg/txm/orchestrator.go
@@ -49,14 +49,15 @@ type Orchestrator[
 	HEAD chains.Head[BLOCK_HASH],
 ] struct {
 	services.StateMachine
-	lggr           logger.SugaredLogger
-	chainID        *big.Int
-	txm            *Txm
-	txStore        OrchestratorTxStore
-	fwdMgr         *forwarders.FwdMgr
-	keystore       keys.Addresses
-	attemptBuilder OrchestratorAttemptBuilder[BLOCK_HASH, HEAD]
-	resumeCallback txmgr.ResumeCallback
+	lggr                 logger.SugaredLogger
+	chainID              *big.Int
+	txm                  *Txm
+	txStore              OrchestratorTxStore
+	fwdMgr               *forwarders.FwdMgr
+	keystore             keys.Addresses
+	attemptBuilder       OrchestratorAttemptBuilder[BLOCK_HASH, HEAD]
+	resumeCallback       txmgr.ResumeCallback
+	dualBroadcastEnabled bool
 }
 
 func NewTxmOrchestrator[BLOCK_HASH chains.Hashable, HEAD chains.Head[BLOCK_HASH]](
@@ -77,6 +78,20 @@ func NewTxmOrchestrator[BLOCK_HASH chains.Hashable, HEAD chains.Head[BLOCK_HASH]
 		attemptBuilder: attemptBuilder,
 		fwdMgr:         fwdMgr,
 	}
+}
+
+// WithDualBroadcast marks the orchestrator as having a dual-broadcast client wired. When true,
+// jobs that use a secondary EOA (DualTransmission) are allowed to start.
+func (o *Orchestrator[BLOCK_HASH, HEAD]) WithDualBroadcast() *Orchestrator[BLOCK_HASH, HEAD] {
+	o.dualBroadcastEnabled = true
+	return o
+}
+
+// SupportsDualBroadcast returns true when the orchestrator was built with a dual-broadcast client,
+// meaning secondary (DualBroadcast) transactions will be routed to the private relay rather than
+// the public mempool.
+func (o *Orchestrator[BLOCK_HASH, HEAD]) SupportsDualBroadcast() bool {
+	return o.dualBroadcastEnabled
 }
 
 func (o *Orchestrator[BLOCK_HASH, HEAD]) Start(ctx context.Context) error {

--- a/pkg/txm/orchestrator.go
+++ b/pkg/txm/orchestrator.go
@@ -79,9 +79,9 @@ func NewTxmOrchestrator[BLOCK_HASH chains.Hashable, HEAD chains.Head[BLOCK_HASH]
 	}
 }
 
-// SupportsDualBroadcast always returns false for the Orchestrator (TXMv2). When dual-broadcast is
-// enabled, the Orchestrator is wrapped by the legacy Txm, which is the TxManager exposed to
-// callers; that wrapper carries the dualBroadcastEnabled flag derived from the node config.
+// SupportsDualBroadcast always returns false for the Orchestrator. When dual-broadcast is
+// enabled, the Orchestrator is wrapped by the legacy Txm. The wrapper returns dualBroadcastEnabled
+// based on the node config.
 func (o *Orchestrator[BLOCK_HASH, HEAD]) SupportsDualBroadcast() bool {
 	return false
 }

--- a/pkg/txmgr/builder.go
+++ b/pkg/txmgr/builder.go
@@ -46,6 +46,7 @@ func NewTxm(
 	estimator gas.EvmFeeEstimator,
 	headTracker latestAndFinalizedBlockHeadTracker,
 	txmv2wrapper TxManager,
+	dualBroadcastEnabled bool,
 ) (txm TxManager,
 	err error,
 ) {
@@ -78,7 +79,7 @@ func NewTxm(
 	if txConfig.ResendAfterThreshold() > 0 {
 		evmResender = NewEvmResender(lggr, txStore, txmClient, evmTracker, keyStore, txmgr.DefaultResenderPollInterval, chainConfig, txConfig)
 	}
-	txm = NewEvmTxm(chainID, txmCfg, txConfig, keyStore, lggr, checker, fwdMgr, txAttemptBuilder, txStore, evmBroadcaster, evmConfirmer, evmResender, evmTracker, evmFinalizer, txmv2wrapper)
+	txm = NewEvmTxm(chainID, txmCfg, txConfig, keyStore, lggr, checker, fwdMgr, txAttemptBuilder, txStore, evmBroadcaster, evmConfirmer, evmResender, evmTracker, evmFinalizer, txmv2wrapper, dualBroadcastEnabled)
 	return txm, nil
 }
 
@@ -99,8 +100,9 @@ func NewEvmTxm(
 	tracker *Tracker,
 	finalizer Finalizer,
 	txmv2wrapper TxManager,
+	dualBroadcastEnabled bool,
 ) *Txm {
-	return txmgr.NewTxm(chainID, cfg, txCfg, keyStore, lggr, checkerFactory, fwdMgr, txAttemptBuilder, txStore, broadcaster, confirmer, resender, tracker, finalizer, client.NewTxError, txmv2wrapper)
+	return txmgr.NewTxm(chainID, cfg, txCfg, keyStore, lggr, checkerFactory, fwdMgr, txAttemptBuilder, txStore, broadcaster, confirmer, resender, tracker, finalizer, client.NewTxError, txmv2wrapper, dualBroadcastEnabled)
 }
 
 func NewTxmV2(
@@ -162,9 +164,6 @@ func NewTxmV2(
 	}
 	t := txm.NewTxm(lggr, chainID, c, attemptBuilder, inMemoryStoreManager, stuckTxDetector, config, keyStore, eh)
 	o := txm.NewTxmOrchestrator(lggr, chainID, t, inMemoryStoreManager, fwdMgr, keyStore, attemptBuilder)
-	if dualBroadcast {
-		o.WithDualBroadcast()
-	}
 	return o, nil
 }
 

--- a/pkg/txmgr/builder.go
+++ b/pkg/txmgr/builder.go
@@ -150,7 +150,8 @@ func NewTxmV2(
 	}
 	var eh txm.ErrorHandler
 	var c txm.Client
-	if txmV2Config.DualBroadcast() != nil && *txmV2Config.DualBroadcast() && txmV2Config.CustomURL() != nil {
+	dualBroadcast := txmV2Config.DualBroadcast() != nil && *txmV2Config.DualBroadcast() && txmV2Config.CustomURL() != nil
+	if dualBroadcast {
 		var err error
 		c, eh, err = dualbroadcast.SelectClient(lggr, client, keyStore, txmV2Config.CustomURL(), chainID, inMemoryStoreManager, txmV2Config.Bundles(), txmV2Config.FastlaneAuctionRequestTimeout())
 		if err != nil {
@@ -160,7 +161,11 @@ func NewTxmV2(
 		c = clientwrappers.NewChainClient(client)
 	}
 	t := txm.NewTxm(lggr, chainID, c, attemptBuilder, inMemoryStoreManager, stuckTxDetector, config, keyStore, eh)
-	return txm.NewTxmOrchestrator(lggr, chainID, t, inMemoryStoreManager, fwdMgr, keyStore, attemptBuilder), nil
+	o := txm.NewTxmOrchestrator(lggr, chainID, t, inMemoryStoreManager, fwdMgr, keyStore, attemptBuilder)
+	if dualBroadcast {
+		o.WithDualBroadcast()
+	}
+	return o, nil
 }
 
 // NewEvmResender creates a new concrete EvmResender

--- a/pkg/txmgr/builder.go
+++ b/pkg/txmgr/builder.go
@@ -152,8 +152,7 @@ func NewTxmV2(
 	}
 	var eh txm.ErrorHandler
 	var c txm.Client
-	dualBroadcast := txmV2Config.DualBroadcast() != nil && *txmV2Config.DualBroadcast() && txmV2Config.CustomURL() != nil
-	if dualBroadcast {
+	if txmV2Config.DualBroadcast() != nil && *txmV2Config.DualBroadcast() && txmV2Config.CustomURL() != nil {
 		var err error
 		c, eh, err = dualbroadcast.SelectClient(lggr, client, keyStore, txmV2Config.CustomURL(), chainID, inMemoryStoreManager, txmV2Config.Bundles(), txmV2Config.FastlaneAuctionRequestTimeout())
 		if err != nil {
@@ -163,8 +162,7 @@ func NewTxmV2(
 		c = clientwrappers.NewChainClient(client)
 	}
 	t := txm.NewTxm(lggr, chainID, c, attemptBuilder, inMemoryStoreManager, stuckTxDetector, config, keyStore, eh)
-	o := txm.NewTxmOrchestrator(lggr, chainID, t, inMemoryStoreManager, fwdMgr, keyStore, attemptBuilder)
-	return o, nil
+	return txm.NewTxmOrchestrator(lggr, chainID, t, inMemoryStoreManager, fwdMgr, keyStore, attemptBuilder), nil
 }
 
 // NewEvmResender creates a new concrete EvmResender

--- a/pkg/txmgr/evm_tx_store_test.go
+++ b/pkg/txmgr/evm_tx_store_test.go
@@ -1303,7 +1303,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 		evmTxmCfg := txmgr.NewEvmTxmConfig(ccfg.EVM())
 		ec := clienttest.NewClientWithDefaultChainID(t)
 		txMgr := txmgr.NewEvmTxm(ec.ConfiguredChainID(), evmTxmCfg, ccfg.EVM().Transactions(), nil, logger.Test(t), nil, nil,
-			nil, txStore, nil, nil, nil, nil, nil, nil)
+			nil, txStore, nil, nil, nil, nil, nil, nil, false)
 		err := txMgr.XXXTestAbandon(fromAddress) // mark transaction as abandoned
 		require.NoError(t, err)
 

--- a/pkg/txmgr/mocks/tx_manager.go
+++ b/pkg/txmgr/mocks/tx_manager.go
@@ -1252,6 +1252,51 @@ func (_c *TxManager_Start_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) RunAndR
 	return _c
 }
 
+// SupportsDualBroadcast provides a mock function with no fields
+func (_m *TxManager[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) SupportsDualBroadcast() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for SupportsDualBroadcast")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// TxManager_SupportsDualBroadcast_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SupportsDualBroadcast'
+type TxManager_SupportsDualBroadcast_Call[CID chains.ID, HEAD chains.Head[BHASH], ADDR chains.Hashable, THASH chains.Hashable, BHASH chains.Hashable, SEQ chains.Sequence, FEE fees.Fee] struct {
+	*mock.Call
+}
+
+// SupportsDualBroadcast is a helper method to define mock.On call
+func (_e *TxManager_Expecter[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) SupportsDualBroadcast() *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
+	return &TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]{Call: _e.mock.On("SupportsDualBroadcast")}
+}
+
+func (_c *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) Run(run func()) *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) Return(_a0 bool) *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) RunAndReturn(run func() bool) *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Trigger provides a mock function with given fields: addr
 func (_m *TxManager[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) Trigger(addr ADDR) {
 	_m.Called(addr)
@@ -1282,50 +1327,6 @@ func (_c *TxManager_Trigger_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) Retur
 
 func (_c *TxManager_Trigger_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) RunAndReturn(run func(ADDR)) *TxManager_Trigger_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
 	_c.Run(run)
-	return _c
-}
-
-// SupportsDualBroadcast provides a mock function with given fields:
-func (_m *TxManager[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) SupportsDualBroadcast() bool {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for SupportsDualBroadcast")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// TxManager_SupportsDualBroadcast_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SupportsDualBroadcast'
-type TxManager_SupportsDualBroadcast_Call[CID chains.ID, HEAD chains.Head[BHASH], ADDR chains.Hashable, THASH chains.Hashable, BHASH chains.Hashable, SEQ chains.Sequence, FEE fees.Fee] struct {
-	*mock.Call
-}
-
-func (_e *TxManager_Expecter[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) SupportsDualBroadcast() *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
-	return &TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]{Call: _e.mock.On("SupportsDualBroadcast")}
-}
-
-func (_c *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) Run(run func()) *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) Return(r0 bool) *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
-	_c.Call.Return(r0)
-	return _c
-}
-
-func (_c *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) RunAndReturn(run func() bool) *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
-	_c.Call.Return(run)
 	return _c
 }
 

--- a/pkg/txmgr/mocks/tx_manager.go
+++ b/pkg/txmgr/mocks/tx_manager.go
@@ -1285,6 +1285,50 @@ func (_c *TxManager_Trigger_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) RunAn
 	return _c
 }
 
+// SupportsDualBroadcast provides a mock function with given fields:
+func (_m *TxManager[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) SupportsDualBroadcast() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for SupportsDualBroadcast")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// TxManager_SupportsDualBroadcast_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SupportsDualBroadcast'
+type TxManager_SupportsDualBroadcast_Call[CID chains.ID, HEAD chains.Head[BHASH], ADDR chains.Hashable, THASH chains.Hashable, BHASH chains.Hashable, SEQ chains.Sequence, FEE fees.Fee] struct {
+	*mock.Call
+}
+
+func (_e *TxManager_Expecter[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) SupportsDualBroadcast() *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
+	return &TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]{Call: _e.mock.On("SupportsDualBroadcast")}
+}
+
+func (_c *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) Run(run func()) *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) Return(r0 bool) *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
+	_c.Call.Return(r0)
+	return _c
+}
+
+func (_c *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) RunAndReturn(run func() bool) *TxManager_SupportsDualBroadcast_Call[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE] {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewTxManager creates a new instance of TxManager. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewTxManager[CID chains.ID, HEAD chains.Head[BHASH], ADDR chains.Hashable, THASH chains.Hashable, BHASH chains.Hashable, SEQ chains.Sequence, FEE fees.Fee](t interface {

--- a/pkg/txmgr/txmgr_test.go
+++ b/pkg/txmgr/txmgr_test.go
@@ -88,7 +88,8 @@ func makeTestEvmTxm(
 		keyStore,
 		estimator,
 		ht,
-		nil)
+		nil,
+		false)
 }
 
 func TestTxm_SendNativeToken_DoesNotSendToZero(t *testing.T) {


### PR DESCRIPTION
### Description

Add `supportsDualBroadcast()` to txmgr. 
This is so that when a job for an SVR feed starts running, we validate whether the txm actually supports dual broadcast. If it doesn't, the job doesn't start. 

### Why

We encountered the following (INC-2328): a NOP had wrongly disabled Txmv2 but was still running an SVR feed. Secondary transactions for this feed were sent using txmv1 to the public mempool. 


### Requires Dependencies
https://github.com/smartcontractkit/chainlink-framework/pull/87

### Supports
https://github.com/smartcontractkit/chainlink/pull/21548