### PR TITLE
add new config value for metaclient

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -391,6 +391,7 @@ BlockTime = '10s' # Example
 CustomURL = 'https://example.api.io' # Example
 DualBroadcast = false # Example
 Bundles = false # Example
+FastlaneAuctionRequestTimeout = '5s' # Example
 ```
 
 
@@ -423,6 +424,12 @@ DualBroadcast enables DualBroadcast functionality.
 Bundles = false # Example
 ```
 Bundles enables sending bundles for auctioning (not compatible with all OFAs).
+
+### FastlaneAuctionRequestTimeout
+```toml
+FastlaneAuctionRequestTimeout = '5s' # Example
+```
+FastlaneAuctionRequestTimeout configures the HTTP request timeout for Fastlane Atlas auction requests. Defaults to 5s if not set.
 
 ## BalanceMonitor
 ```toml

--- a/pkg/config/chain_scoped_transactions.go
+++ b/pkg/config/chain_scoped_transactions.go
@@ -68,6 +68,14 @@ func (t *transactionManagerV2Config) Bundles() *bool {
 	return t.c.Bundles
 }
 
+func (t *transactionManagerV2Config) FastlaneAuctionRequestTimeout() *time.Duration {
+	if t.c.FastlaneAuctionRequestTimeout == nil {
+		return nil
+	}
+	d := t.c.FastlaneAuctionRequestTimeout.Duration()
+	return &d
+}
+
 func (t *transactionsConfig) AutoPurge() AutoPurgeConfig {
 	return &autoPurgeConfig{c: t.c.AutoPurge}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,6 +134,7 @@ type TransactionManagerV2 interface {
 	CustomURL() *url.URL
 	DualBroadcast() *bool
 	Bundles() *bool
+	FastlaneAuctionRequestTimeout() *time.Duration
 }
 
 type GasEstimator interface {

--- a/pkg/config/toml/config.go
+++ b/pkg/config/toml/config.go
@@ -585,11 +585,12 @@ func (a *AutoPurgeConfig) setFrom(f *AutoPurgeConfig) {
 }
 
 type TransactionManagerV2Config struct {
-	Enabled       *bool                  `toml:",omitempty"`
-	BlockTime     *commonconfig.Duration `toml:",omitempty"`
-	CustomURL     *commonconfig.URL      `toml:",omitempty"`
-	DualBroadcast *bool                  `toml:",omitempty"`
-	Bundles       *bool                  `toml:",omitempty"`
+	Enabled                       *bool                  `toml:",omitempty"`
+	BlockTime                     *commonconfig.Duration `toml:",omitempty"`
+	CustomURL                     *commonconfig.URL      `toml:",omitempty"`
+	DualBroadcast                 *bool                  `toml:",omitempty"`
+	Bundles                       *bool                  `toml:",omitempty"`
+	FastlaneAuctionRequestTimeout *commonconfig.Duration `toml:",omitempty"`
 }
 
 func (t *TransactionManagerV2Config) setFrom(f *TransactionManagerV2Config) {
@@ -607,6 +608,9 @@ func (t *TransactionManagerV2Config) setFrom(f *TransactionManagerV2Config) {
 	}
 	if v := f.Bundles; v != nil {
 		t.Bundles = f.Bundles
+	}
+	if v := f.FastlaneAuctionRequestTimeout; v != nil {
+		t.FastlaneAuctionRequestTimeout = f.FastlaneAuctionRequestTimeout
 	}
 }
 

--- a/pkg/config/toml/config_test.go
+++ b/pkg/config/toml/config_test.go
@@ -65,6 +65,7 @@ func TestDefaults_fieldsNotNil(t *testing.T) {
 	unknown.Transactions.TransactionManagerV2.CustomURL = new(config.URL)
 	unknown.Transactions.TransactionManagerV2.DualBroadcast = ptr(false)
 	unknown.Transactions.TransactionManagerV2.Bundles = ptr(false)
+	unknown.Transactions.TransactionManagerV2.FastlaneAuctionRequestTimeout = new(config.Duration)
 	unknown.Transactions.AutoPurge.Threshold = ptr(uint32(0))
 	unknown.Transactions.AutoPurge.MinAttempts = ptr(uint32(0))
 	unknown.Transactions.AutoPurge.DetectionApiUrl = new(config.URL)
@@ -161,6 +162,7 @@ func TestDocs(t *testing.T) {
 		docDefaults.Transactions.TransactionManagerV2.CustomURL = nil
 		docDefaults.Transactions.TransactionManagerV2.DualBroadcast = nil
 		docDefaults.Transactions.TransactionManagerV2.Bundles = nil
+		docDefaults.Transactions.TransactionManagerV2.FastlaneAuctionRequestTimeout = nil
 
 		// Fallback DA oracle is not set
 		docDefaults.GasEstimator.DAOracle = DAOracle{}
@@ -283,11 +285,12 @@ var fullConfig = EVMConfig{
 				DetectionApiUrl: config.MustParseURL("http://example.net"),
 			},
 			TransactionManagerV2: TransactionManagerV2Config{
-				Enabled:       ptr(false),
-				DualBroadcast: ptr(true),
-				Bundles:       ptr(false),
-				BlockTime:     config.MustNewDuration(42 * time.Second),
-				CustomURL:     config.MustParseURL("http://txs.org"),
+				Enabled:                       ptr(false),
+				DualBroadcast:                 ptr(true),
+				Bundles:                       ptr(false),
+				BlockTime:                     config.MustNewDuration(42 * time.Second),
+				CustomURL:                     config.MustParseURL("http://txs.org"),
+				FastlaneAuctionRequestTimeout: config.MustNewDuration(15 * time.Second),
 			},
 		},
 

--- a/pkg/config/toml/docs.toml
+++ b/pkg/config/toml/docs.toml
@@ -173,6 +173,8 @@ CustomURL = 'https://example.api.io' # Example
 DualBroadcast = false # Example
 # Bundles enables sending bundles for auctioning (not compatible with all OFAs).
 Bundles = false # Example
+# FastlaneAuctionRequestTimeout configures the HTTP request timeout for Fastlane Atlas auction requests. Defaults to 5s if not set.
+FastlaneAuctionRequestTimeout = '5s' # Example
 
 [BalanceMonitor]
 # Enabled balance monitoring for all keys.

--- a/pkg/config/toml/testdata/config-full.toml
+++ b/pkg/config/toml/testdata/config-full.toml
@@ -48,6 +48,7 @@ BlockTime = '42s'
 CustomURL = 'http://txs.org'
 DualBroadcast = true
 Bundles = false
+FastlaneAuctionRequestTimeout = '15s'
 
 [BalanceMonitor]
 Enabled = true

--- a/pkg/txm/clientwrappers/dualbroadcast/meta_client.go
+++ b/pkg/txm/clientwrappers/dualbroadcast/meta_client.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	timeout                    = time.Second * 5
+	defaultAuctionRequestTimeout = time.Second * 5
 	NoSolverOps                = "no solver operations received"
 	NoSolverOpsAfterSimulation = "no valid solver operations after simulation"
 	metaABI                    = `[
@@ -136,29 +136,36 @@ type MetaClientRPC interface {
 }
 
 type MetaClient struct {
-	lggr      logger.SugaredLogger
-	c         MetaClientRPC
-	ks        MetaClientKeystore
-	customURL *url.URL
-	chainID   *big.Int
-	metrics   *MetaMetrics
-	txStore   MetaClientTxStore
+	lggr                  logger.SugaredLogger
+	c                     MetaClientRPC
+	ks                    MetaClientKeystore
+	customURL             *url.URL
+	chainID               *big.Int
+	metrics               *MetaMetrics
+	txStore               MetaClientTxStore
+	auctionRequestTimeout time.Duration
 }
 
-func NewMetaClient(lggr logger.Logger, c MetaClientRPC, ks MetaClientKeystore, customURL *url.URL, chainID *big.Int, txStore MetaClientTxStore) (*MetaClient, error) {
+func NewMetaClient(lggr logger.Logger, c MetaClientRPC, ks MetaClientKeystore, customURL *url.URL, chainID *big.Int, txStore MetaClientTxStore, auctionRequestTimeout *time.Duration) (*MetaClient, error) {
 	metrics, err := NewMetaMetrics(chainID.String(), lggr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Meta metrics: %w", err)
 	}
 
+	t := defaultAuctionRequestTimeout
+	if auctionRequestTimeout != nil {
+		t = *auctionRequestTimeout
+	}
+
 	return &MetaClient{
-		lggr:      logger.Sugared(logger.Named(lggr, "Txm.MetaClient")),
-		c:         c,
-		ks:        ks,
-		customURL: customURL,
-		chainID:   chainID,
-		metrics:   metrics,
-		txStore:   txStore,
+		lggr:                  logger.Sugared(logger.Named(lggr, "Txm.MetaClient")),
+		c:                     c,
+		ks:                    ks,
+		customURL:             customURL,
+		chainID:               chainID,
+		metrics:               metrics,
+		txStore:               txStore,
+		auctionRequestTimeout: t,
 	}, nil
 }
 
@@ -309,7 +316,7 @@ type Metacalldata struct {
 }
 
 func (a *MetaClient) SendRequest(parentCtx context.Context, tx *types.Transaction, attempt *types.Attempt, dualBroadcastParams string, fwdrDestAddress common.Address) (*MetacalldataResponse, error) {
-	ctx, cancel := context.WithTimeout(parentCtx, timeout)
+	ctx, cancel := context.WithTimeout(parentCtx, a.auctionRequestTimeout)
 	defer cancel()
 
 	m := []byte{97, 116, 108, 97, 115, 95, 111, 101, 118, 65, 117, 99, 116, 105, 111, 110}

--- a/pkg/txm/clientwrappers/dualbroadcast/selector.go
+++ b/pkg/txm/clientwrappers/dualbroadcast/selector.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -12,13 +13,13 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/txm"
 )
 
-func SelectClient(lggr logger.Logger, client client.Client, keyStore keys.ChainStore, url *url.URL, chainID *big.Int, txStore txm.TxStore, bundles *bool) (txm.Client, txm.ErrorHandler, error) {
+func SelectClient(lggr logger.Logger, client client.Client, keyStore keys.ChainStore, url *url.URL, chainID *big.Int, txStore txm.TxStore, bundles *bool, auctionRequestTimeout *time.Duration) (txm.Client, txm.ErrorHandler, error) {
 	urlString := url.String()
 	switch {
 	case strings.Contains(urlString, "flashbots"):
 		return NewFlashbotsClient(lggr, client, keyStore, url, txStore, bundles), nil, nil
 	default:
-		mc, err := NewMetaClient(lggr, client, keyStore, url, chainID, txStore)
+		mc, err := NewMetaClient(lggr, client, keyStore, url, chainID, txStore, auctionRequestTimeout)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/txmgr/builder.go
+++ b/pkg/txmgr/builder.go
@@ -152,7 +152,7 @@ func NewTxmV2(
 	var c txm.Client
 	if txmV2Config.DualBroadcast() != nil && *txmV2Config.DualBroadcast() && txmV2Config.CustomURL() != nil {
 		var err error
-		c, eh, err = dualbroadcast.SelectClient(lggr, client, keyStore, txmV2Config.CustomURL(), chainID, inMemoryStoreManager, txmV2Config.Bundles())
+		c, eh, err = dualbroadcast.SelectClient(lggr, client, keyStore, txmV2Config.CustomURL(), chainID, inMemoryStoreManager, txmV2Config.Bundles(), txmV2Config.FastlaneAuctionRequestTimeout())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create dual broadcast client: %w", err)
 		}


### PR DESCRIPTION
Adds a timeout config for the metaclient http auction request (default is kept at 5). 

Improtant change because we are actively exceeding this context deadline