### PR TITLE
OEV-1013: add logging and better metrics for hitting api

### DIFF
--- a/pkg/txm/clientwrappers/dualbroadcast/meta_client.go
+++ b/pkg/txm/clientwrappers/dualbroadcast/meta_client.go
@@ -316,9 +316,6 @@ type Metacalldata struct {
 }
 
 func (a *MetaClient) SendRequest(parentCtx context.Context, tx *types.Transaction, attempt *types.Attempt, dualBroadcastParams string, fwdrDestAddress common.Address) (*MetacalldataResponse, error) {
-	ctx, cancel := context.WithTimeout(parentCtx, a.auctionRequestTimeout)
-	defer cancel()
-
 	m := []byte{97, 116, 108, 97, 115, 95, 111, 101, 118, 65, 117, 99, 116, 105, 111, 110}
 
 	cid := hexutil.Uint64(a.chainID.Uint64())
@@ -357,22 +354,40 @@ func (a *MetaClient) SendRequest(parentCtx context.Context, tx *types.Transactio
 		return nil, fmt.Errorf("failed to marshal signed params: %w", err)
 	}
 	body := fmt.Appendf(nil, `{"jsonrpc":"2.0","method":"%s","params":[%s], "id":1}`, string(m), marshalledParamsExtended)
+
+	// Start timing for endpoint latency measurement
+	// Latency should be > than the context timer to query context-timeout requests
+	// (opt to overcount rather than undercount reqs with timeout)
+	startTime := time.Now()
+	ctx, cancel := context.WithTimeout(parentCtx, a.auctionRequestTimeout)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.customURL.String(), bytes.NewBuffer(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create POST request: %w", err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 
-	// Start timing for endpoint latency measurement
-	startTime := time.Now()
 	resp, err := http.DefaultClient.Do(req)
+
 	latency := time.Since(startTime)
 
 	// Record latency
 	a.metrics.RecordLatency(ctx, latency)
+
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			a.lggr.Info("Auction Request Context Deadline Exceeded")
+			// mark status code "7" as context deadline exceeded
+			// definitive source of context-exceeded requests
+			a.metrics.RecordStatusCode(ctx, 7)
+		} else {
+			// mark status code "0" as all other errors to track the # of attempts
+			a.metrics.RecordStatusCode(ctx, 0)
+		}
+
 		return nil, fmt.Errorf("failed to send POST request: %w", err)
 	}
+
 	defer resp.Body.Close()
 
 	// Record status code

--- a/pkg/txm/clientwrappers/dualbroadcast/meta_client.go
+++ b/pkg/txm/clientwrappers/dualbroadcast/meta_client.go
@@ -385,7 +385,7 @@ func (a *MetaClient) SendRequest(parentCtx context.Context, tx *types.Transactio
 			a.metrics.RecordStatusCode(ctx, 0)
 		}
 
-		return nil, fmt.Errorf("failed to send POST request: %w", err)
+		return nil, fmt.Errorf("failed to send POST request with latency %s: %w", latency, err)
 	}
 
 	defer resp.Body.Close()

--- a/pkg/txm/clientwrappers/dualbroadcast/meta_metrics.go
+++ b/pkg/txm/clientwrappers/dualbroadcast/meta_metrics.go
@@ -36,7 +36,11 @@ func NewMetaMetrics(chainID string, lggr logger.Logger) (*MetaMetrics, error) {
 		return nil, err
 	}
 
-	latencyHistogram, err := beholder.GetMeter().Int64Histogram("meta_endpoint_latency")
+	latencyHistogram, err := beholder.GetMeter().Int64Histogram("meta_endpoint_latency",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Latency of Meta auction endpoint requests"),
+		metric.WithExplicitBucketBoundaries(500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 7500, 10000),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Couple changes here:
- Add logging statement when context deadline exceeds
- Change histogram bins to be more granular from 0-5s mark. 
- Introduce reporting "0xx" status codes which are attempts with no server response. "7" is context-deadline exceeded and "0" is catch all. This way we can track the number of attempts via the status code metric as well (because the latency metric could overcount / undercount the timeouts)
- Move context deadline closer to the start time measurement
- Start the latency timer before the context timer, so that we overestimate rather than underestimate the time. So that, if you were to pull the latencies > [timeout duration] you'd be overcounting rather than undercounting.

The most precise way to find the amount of context-deadline exceeded errors is by looking at the status codes. 
