### PR TITLE
OEV-832 Ingest block_history_estimator and fee_history_estimator metrics into Beholder

### DIFF
--- a/pkg/gas/block_history_estimator.go
+++ b/pkg/gas/block_history_estimator.go
@@ -645,6 +645,7 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(ctx context.Context, lgg
 	}...)
 	lggr.Debugw(fmt.Sprintf("Setting new default prices, GasPrice: %v Gwei, TipCap: %v Gwei", gasPriceGwei, tipCapGwei), lggrFields...)
 	b.setPercentileTipCap(percentileTipCap)
+
 	promBlockHistoryEstimatorSetTipCap.WithLabelValues(percentileLabel, chainIDStr).Set(float64(percentileTipCap.Int64()))
 	if b.tipCapGauge != nil {
 		b.tipCapGauge.Record(ctx, float64(percentileTipCap.Int64()), metric.WithAttributes(

--- a/pkg/gas/block_history_estimator.go
+++ b/pkg/gas/block_history_estimator.go
@@ -13,12 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
@@ -37,45 +32,6 @@ import (
 // trying to fill initial data on start. This must be capped because it can
 // block the application from starting.
 var MaxStartTime = 10 * time.Second
-
-var (
-	promBlockHistoryEstimatorAllGasPricePercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_all_gas_price_percentiles",
-		Help: "Gas price at given percentile",
-	},
-		[]string{"percentile", "evmChainID"},
-	)
-	promBlockHistoryEstimatorAllTipCapPercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_all_tip_cap_percentiles",
-		Help: "Tip cap at given percentile",
-	},
-		[]string{"percentile", "evmChainID"},
-	)
-	promBlockHistoryEstimatorSetGasPrice = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_set_gas_price",
-		Help: "Gas updater set gas price (in Wei)",
-	},
-		[]string{"percentile", "evmChainID"},
-	)
-	promBlockHistoryEstimatorSetTipCap = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_set_tip_cap",
-		Help: "Gas updater set gas tip cap (in Wei)",
-	},
-		[]string{"percentile", "evmChainID"},
-	)
-	promBlockHistoryEstimatorCurrentBaseFee = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_current_base_fee",
-		Help: "Gas updater current block base fee in Wei",
-	},
-		[]string{"evmChainID"},
-	)
-	promBlockHistoryEstimatorConnectivityFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "block_history_estimator_connectivity_failure_count",
-		Help: "Counter is incremented every time a gas bump is prevented due to a detected network propagation/connectivity issue",
-	},
-		[]string{"evmChainID", "mode"},
-	)
-)
 
 const BumpingHaltedLabel = "Tx gas bumping halted since price exceeds current block prices by significant margin; tx will continue to be rebroadcasted but your node, RPC, or the chain might be experiencing connectivity issues; please investigate and fix ASAP"
 
@@ -120,13 +76,7 @@ type BlockHistoryEstimator struct {
 
 	l1Oracle rollups.L1Oracle
 
-	// Optional Beholder OTel metrics (nil if registration failed); same names as Prometheus for consistency
-	gasPriceGauge                   metric.Float64Gauge
-	tipCapGauge                     metric.Float64Gauge
-	allGasPricePercentilesGauge     metric.Float64Gauge
-	allTipCapPercentilesGauge       metric.Float64Gauge
-	currentBaseFeeGauge             metric.Float64Gauge
-	connectivityFailureCountCounter metric.Int64Counter
+	metrics *blockHistoryEstimatorMetrics
 }
 
 // NewBlockHistoryEstimator returns a new BlockHistoryEstimator that listens
@@ -148,36 +98,7 @@ func NewBlockHistoryEstimator(lggr logger.Logger, ethClient FeeEstimatorClient, 
 		stopCh:   make(chan struct{}),
 		logger:   l,
 		l1Oracle: l1Oracle,
-	}
-	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_set_gas_price"); err != nil {
-		l.Errorw("Failed to register Beholder gas_updater_set_gas_price gauge", "err", err)
-	} else {
-		b.gasPriceGauge = g
-	}
-	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_set_tip_cap"); err != nil {
-		l.Errorw("Failed to register Beholder gas_updater_set_tip_cap gauge", "err", err)
-	} else {
-		b.tipCapGauge = g
-	}
-	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_all_gas_price_percentiles"); err != nil {
-		l.Warnw("Failed to register Beholder gas_updater_all_gas_price_percentiles gauge", "err", err)
-	} else {
-		b.allGasPricePercentilesGauge = g
-	}
-	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_all_tip_cap_percentiles"); err != nil {
-		l.Warnw("Failed to register Beholder gas_updater_all_tip_cap_percentiles gauge", "err", err)
-	} else {
-		b.allTipCapPercentilesGauge = g
-	}
-	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_current_base_fee"); err != nil {
-		l.Warnw("Failed to register Beholder gas_updater_current_base_fee gauge", "err", err)
-	} else {
-		b.currentBaseFeeGauge = g
-	}
-	if c, err := beholder.GetMeter().Int64Counter("block_history_estimator_connectivity_failure_count"); err != nil {
-		l.Warnw("Failed to register Beholder block_history_estimator_connectivity_failure_count counter", "err", err)
-	} else {
-		b.connectivityFailureCountCounter = c
+		metrics:  newBlockHistoryEstimatorMetrics(l, chainID),
 	}
 	return b
 }
@@ -195,13 +116,7 @@ func (b *BlockHistoryEstimator) OnNewLongestChain(_ context.Context, head *evmty
 func (b *BlockHistoryEstimator) setLatest(head *evmtypes.Head) {
 	// Non-eip1559 blocks don't include base fee
 	if baseFee := head.BaseFeePerGas; baseFee != nil {
-		chainIDStr := b.chainID.String()
-		promBlockHistoryEstimatorCurrentBaseFee.WithLabelValues(chainIDStr).Set(float64(baseFee.Int64()))
-		if b.currentBaseFeeGauge != nil {
-			b.currentBaseFeeGauge.Record(context.Background(), float64(baseFee.Int64()), metric.WithAttributes(
-				attribute.String("chainID", chainIDStr),
-			))
-		}
+		b.metrics.RecordCurrentBaseFee(float64(baseFee.Int64()))
 	}
 
 	b.logger.Debugw("Set latest block", "blockNum", head.Number, "blockHash", head.Hash, "baseFee", head.BaseFeePerGas, "baseFeeWei", head.BaseFeePerGas.ToInt())
@@ -374,15 +289,7 @@ func (b *BlockHistoryEstimator) BumpLegacyGas(ctx context.Context, originalGasPr
 			if errors.Is(err, fees.ErrConnectivity) {
 				b.logger.Criticalw(BumpingHaltedLabel, "err", err)
 				b.SvcErrBuffer.Append(err)
-
-				chainIDStr := b.chainID.String()
-				promBlockHistoryEstimatorConnectivityFailureCount.WithLabelValues(chainIDStr, "legacy").Inc()
-				if b.connectivityFailureCountCounter != nil {
-					b.connectivityFailureCountCounter.Add(ctx, 1, metric.WithAttributes(
-						attribute.String("chainID", chainIDStr),
-						attribute.String("mode", "legacy"),
-					))
-				}
+				b.metrics.RecordConnectivityFailure(ctx, "legacy")
 			}
 			return nil, 0, err
 		}
@@ -563,14 +470,7 @@ func (b *BlockHistoryEstimator) BumpDynamicFee(ctx context.Context, originalFee 
 				b.logger.Criticalw(BumpingHaltedLabel, "err", err)
 				b.SvcErrBuffer.Append(err)
 
-				chainIDStr := b.chainID.String()
-				promBlockHistoryEstimatorConnectivityFailureCount.WithLabelValues(chainIDStr, "eip1559").Inc()
-				if b.connectivityFailureCountCounter != nil {
-					b.connectivityFailureCountCounter.Add(ctx, 1, metric.WithAttributes(
-						attribute.String("chainID", chainIDStr),
-						attribute.String("mode", "eip1559"),
-					))
-				}
+				b.metrics.RecordConnectivityFailure(ctx, "eip1559")
 			}
 			return bumped, err
 		}
@@ -633,33 +533,18 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(ctx context.Context, lgg
 	startIdx := len(blockHistory) - blockRange
 	blocks := blockHistory[startIdx:]
 
-	chainIDStr := b.chainID.String()
 	percentileGasPrice, percentileTipCap, err := b.calculatePercentilePrices(blocks, percentile, eip1559,
 		func(gasPrices []*assets.Wei) {
 			for i := 0; i <= 100; i += 5 {
 				jdx := ((len(gasPrices) - 1) * i) / 100
 				percentileLabel := fmt.Sprintf("%v%%", i)
-				val := float64(gasPrices[jdx].Int64())
-				promBlockHistoryEstimatorAllGasPricePercentiles.WithLabelValues(percentileLabel, chainIDStr).Set(val)
-				if b.allGasPricePercentilesGauge != nil {
-					b.allGasPricePercentilesGauge.Record(ctx, val, metric.WithAttributes(
-						attribute.String("chainID", chainIDStr),
-						attribute.String("percentile", percentileLabel),
-					))
-				}
+				b.metrics.RecordAllGasPricePercentile(ctx, percentileLabel, float64(gasPrices[jdx].Int64()))
 			}
 		}, func(tipCaps []*assets.Wei) {
 			for i := 0; i <= 100; i += 5 {
 				jdx := ((len(tipCaps) - 1) * i) / 100
 				percentileLabel := fmt.Sprintf("%v%%", i)
-				val := float64(tipCaps[jdx].Int64())
-				promBlockHistoryEstimatorAllTipCapPercentiles.WithLabelValues(percentileLabel, chainIDStr).Set(val)
-				if b.allTipCapPercentilesGauge != nil {
-					b.allTipCapPercentilesGauge.Record(ctx, val, metric.WithAttributes(
-						attribute.String("chainID", chainIDStr),
-						attribute.String("percentile", percentileLabel),
-					))
-				}
+				b.metrics.RecordAllTipCapPercentile(ctx, percentileLabel, float64(tipCaps[jdx].Int64()))
 			}
 		})
 	if err != nil {
@@ -687,13 +572,7 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(ctx context.Context, lgg
 	b.setPercentileGasPrice(percentileGasPrice)
 
 	percentileLabel := fmt.Sprintf("%v%%", percentile)
-	promBlockHistoryEstimatorSetGasPrice.WithLabelValues(percentileLabel, chainIDStr).Set(float64(percentileGasPrice.Int64()))
-	if b.gasPriceGauge != nil {
-		b.gasPriceGauge.Record(ctx, float64(percentileGasPrice.Int64()), metric.WithAttributes(
-			attribute.String("chainID", chainIDStr),
-			attribute.String("percentile", percentileLabel),
-		))
-	}
+	b.metrics.RecordSetGasPrice(ctx, percentileLabel, float64(percentileGasPrice.Int64()))
 
 	if !eip1559 {
 		lggr.Debugw(fmt.Sprintf("Setting new default GasPrice: %v Gwei", gasPriceGwei), lggrFields...)
@@ -708,13 +587,7 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(ctx context.Context, lgg
 	lggr.Debugw(fmt.Sprintf("Setting new default prices, GasPrice: %v Gwei, TipCap: %v Gwei", gasPriceGwei, tipCapGwei), lggrFields...)
 	b.setPercentileTipCap(percentileTipCap)
 
-	promBlockHistoryEstimatorSetTipCap.WithLabelValues(percentileLabel, chainIDStr).Set(float64(percentileTipCap.Int64()))
-	if b.tipCapGauge != nil {
-		b.tipCapGauge.Record(ctx, float64(percentileTipCap.Int64()), metric.WithAttributes(
-			attribute.String("chainID", chainIDStr),
-			attribute.String("percentile", percentileLabel),
-		))
-	}
+	b.metrics.RecordSetTipCap(ctx, percentileLabel, float64(percentileTipCap.Int64()))
 }
 
 func (b *BlockHistoryEstimator) calculateMaxPercentileGasPriceTipCap(lggr logger.SugaredLogger, blockHistory []evmtypes.Block, head *evmtypes.Head) {

--- a/pkg/gas/block_history_estimator.go
+++ b/pkg/gas/block_history_estimator.go
@@ -120,9 +120,13 @@ type BlockHistoryEstimator struct {
 
 	l1Oracle rollups.L1Oracle
 
-	// Optional Beholder OTel gauges for gas_updater_set_gas_price / gas_updater_set_tip_cap (nil if registration failed)
-	gasPriceGauge metric.Float64Gauge
-	tipCapGauge   metric.Float64Gauge
+	// Optional Beholder OTel metrics (nil if registration failed); same names as Prometheus for consistency
+	gasPriceGauge                   metric.Float64Gauge
+	tipCapGauge                     metric.Float64Gauge
+	allGasPricePercentilesGauge     metric.Float64Gauge
+	allTipCapPercentilesGauge       metric.Float64Gauge
+	currentBaseFeeGauge             metric.Float64Gauge
+	connectivityFailureCountCounter metric.Int64Counter
 }
 
 // NewBlockHistoryEstimator returns a new BlockHistoryEstimator that listens
@@ -155,7 +159,26 @@ func NewBlockHistoryEstimator(lggr logger.Logger, ethClient FeeEstimatorClient, 
 	} else {
 		b.tipCapGauge = g
 	}
-
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_all_gas_price_percentiles"); err != nil {
+		l.Warnw("Failed to register Beholder gas_updater_all_gas_price_percentiles gauge", "err", err)
+	} else {
+		b.allGasPricePercentilesGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_all_tip_cap_percentiles"); err != nil {
+		l.Warnw("Failed to register Beholder gas_updater_all_tip_cap_percentiles gauge", "err", err)
+	} else {
+		b.allTipCapPercentilesGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_current_base_fee"); err != nil {
+		l.Warnw("Failed to register Beholder gas_updater_current_base_fee gauge", "err", err)
+	} else {
+		b.currentBaseFeeGauge = g
+	}
+	if c, err := beholder.GetMeter().Int64Counter("block_history_estimator_connectivity_failure_count"); err != nil {
+		l.Warnw("Failed to register Beholder block_history_estimator_connectivity_failure_count counter", "err", err)
+	} else {
+		b.connectivityFailureCountCounter = c
+	}
 	return b
 }
 
@@ -172,8 +195,15 @@ func (b *BlockHistoryEstimator) OnNewLongestChain(_ context.Context, head *evmty
 func (b *BlockHistoryEstimator) setLatest(head *evmtypes.Head) {
 	// Non-eip1559 blocks don't include base fee
 	if baseFee := head.BaseFeePerGas; baseFee != nil {
-		promBlockHistoryEstimatorCurrentBaseFee.WithLabelValues(b.chainID.String()).Set(float64(baseFee.Int64()))
+		chainIDStr := b.chainID.String()
+		promBlockHistoryEstimatorCurrentBaseFee.WithLabelValues(chainIDStr).Set(float64(baseFee.Int64()))
+		if b.currentBaseFeeGauge != nil {
+			b.currentBaseFeeGauge.Record(context.Background(), float64(baseFee.Int64()), metric.WithAttributes(
+				attribute.String("chainID", chainIDStr),
+			))
+		}
 	}
+
 	b.logger.Debugw("Set latest block", "blockNum", head.Number, "blockHash", head.Hash, "baseFee", head.BaseFeePerGas, "baseFeeWei", head.BaseFeePerGas.ToInt())
 	b.latestMu.Lock()
 	defer b.latestMu.Unlock()
@@ -338,13 +368,21 @@ func (b *BlockHistoryEstimator) setMaxPercentileTipCap(tipCap *assets.Wei) {
 	b.maxPercentileTipCap = tipCap
 }
 
-func (b *BlockHistoryEstimator) BumpLegacyGas(_ context.Context, originalGasPrice *assets.Wei, gasLimit uint64, maxGasPriceWei *assets.Wei, attempts []EvmPriorAttempt) (bumpedGasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) {
+func (b *BlockHistoryEstimator) BumpLegacyGas(ctx context.Context, originalGasPrice *assets.Wei, gasLimit uint64, maxGasPriceWei *assets.Wei, attempts []EvmPriorAttempt) (bumpedGasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) {
 	if b.bhConfig.CheckInclusionBlocks() > 0 {
 		if err = b.haltBumping(attempts); err != nil {
 			if errors.Is(err, fees.ErrConnectivity) {
 				b.logger.Criticalw(BumpingHaltedLabel, "err", err)
 				b.SvcErrBuffer.Append(err)
-				promBlockHistoryEstimatorConnectivityFailureCount.WithLabelValues(b.chainID.String(), "legacy").Inc()
+
+				chainIDStr := b.chainID.String()
+				promBlockHistoryEstimatorConnectivityFailureCount.WithLabelValues(chainIDStr, "legacy").Inc()
+				if b.connectivityFailureCountCounter != nil {
+					b.connectivityFailureCountCounter.Add(ctx, 1, metric.WithAttributes(
+						attribute.String("chainID", chainIDStr),
+						attribute.String("mode", "legacy"),
+					))
+				}
 			}
 			return nil, 0, err
 		}
@@ -518,13 +556,21 @@ func calcFeeCap(latestAvailableBaseFeePerGas *assets.Wei, bufferBlocks int, tipC
 	return feeCap
 }
 
-func (b *BlockHistoryEstimator) BumpDynamicFee(_ context.Context, originalFee DynamicFee, maxGasPriceWei *assets.Wei, attempts []EvmPriorAttempt) (bumped DynamicFee, err error) {
+func (b *BlockHistoryEstimator) BumpDynamicFee(ctx context.Context, originalFee DynamicFee, maxGasPriceWei *assets.Wei, attempts []EvmPriorAttempt) (bumped DynamicFee, err error) {
 	if b.bhConfig.CheckInclusionBlocks() > 0 {
 		if err = b.haltBumping(attempts); err != nil {
 			if errors.Is(err, fees.ErrConnectivity) {
 				b.logger.Criticalw(BumpingHaltedLabel, "err", err)
 				b.SvcErrBuffer.Append(err)
-				promBlockHistoryEstimatorConnectivityFailureCount.WithLabelValues(b.chainID.String(), "eip1559").Inc()
+
+				chainIDStr := b.chainID.String()
+				promBlockHistoryEstimatorConnectivityFailureCount.WithLabelValues(chainIDStr, "eip1559").Inc()
+				if b.connectivityFailureCountCounter != nil {
+					b.connectivityFailureCountCounter.Add(ctx, 1, metric.WithAttributes(
+						attribute.String("chainID", chainIDStr),
+						attribute.String("mode", "eip1559"),
+					))
+				}
 			}
 			return bumped, err
 		}
@@ -587,16 +633,33 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(ctx context.Context, lgg
 	startIdx := len(blockHistory) - blockRange
 	blocks := blockHistory[startIdx:]
 
+	chainIDStr := b.chainID.String()
 	percentileGasPrice, percentileTipCap, err := b.calculatePercentilePrices(blocks, percentile, eip1559,
 		func(gasPrices []*assets.Wei) {
 			for i := 0; i <= 100; i += 5 {
 				jdx := ((len(gasPrices) - 1) * i) / 100
-				promBlockHistoryEstimatorAllGasPricePercentiles.WithLabelValues(fmt.Sprintf("%v%%", i), b.chainID.String()).Set(float64(gasPrices[jdx].Int64()))
+				percentileLabel := fmt.Sprintf("%v%%", i)
+				val := float64(gasPrices[jdx].Int64())
+				promBlockHistoryEstimatorAllGasPricePercentiles.WithLabelValues(percentileLabel, chainIDStr).Set(val)
+				if b.allGasPricePercentilesGauge != nil {
+					b.allGasPricePercentilesGauge.Record(ctx, val, metric.WithAttributes(
+						attribute.String("chainID", chainIDStr),
+						attribute.String("percentile", percentileLabel),
+					))
+				}
 			}
 		}, func(tipCaps []*assets.Wei) {
 			for i := 0; i <= 100; i += 5 {
 				jdx := ((len(tipCaps) - 1) * i) / 100
-				promBlockHistoryEstimatorAllTipCapPercentiles.WithLabelValues(fmt.Sprintf("%v%%", i), b.chainID.String()).Set(float64(tipCaps[jdx].Int64()))
+				percentileLabel := fmt.Sprintf("%v%%", i)
+				val := float64(tipCaps[jdx].Int64())
+				promBlockHistoryEstimatorAllTipCapPercentiles.WithLabelValues(percentileLabel, chainIDStr).Set(val)
+				if b.allTipCapPercentilesGauge != nil {
+					b.allTipCapPercentilesGauge.Record(ctx, val, metric.WithAttributes(
+						attribute.String("chainID", chainIDStr),
+						attribute.String("percentile", percentileLabel),
+					))
+				}
 			}
 		})
 	if err != nil {
@@ -624,7 +687,6 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(ctx context.Context, lgg
 	b.setPercentileGasPrice(percentileGasPrice)
 
 	percentileLabel := fmt.Sprintf("%v%%", percentile)
-	chainIDStr := b.chainID.String()
 	promBlockHistoryEstimatorSetGasPrice.WithLabelValues(percentileLabel, chainIDStr).Set(float64(percentileGasPrice.Int64()))
 	if b.gasPriceGauge != nil {
 		b.gasPriceGauge.Record(ctx, float64(percentileGasPrice.Int64()), metric.WithAttributes(
@@ -649,7 +711,7 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(ctx context.Context, lgg
 	promBlockHistoryEstimatorSetTipCap.WithLabelValues(percentileLabel, chainIDStr).Set(float64(percentileTipCap.Int64()))
 	if b.tipCapGauge != nil {
 		b.tipCapGauge.Record(ctx, float64(percentileTipCap.Int64()), metric.WithAttributes(
-			attribute.String("evmChainID", chainIDStr),
+			attribute.String("chainID", chainIDStr),
 			attribute.String("percentile", percentileLabel),
 		))
 	}

--- a/pkg/gas/block_history_estimator.go
+++ b/pkg/gas/block_history_estimator.go
@@ -15,7 +15,10 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
@@ -116,13 +119,18 @@ type BlockHistoryEstimator struct {
 	logger logger.SugaredLogger
 
 	l1Oracle rollups.L1Oracle
+
+	// Optional Beholder OTel gauges for gas_updater_set_gas_price / gas_updater_set_tip_cap (nil if registration failed)
+	gasPriceGauge metric.Float64Gauge
+	tipCapGauge   metric.Float64Gauge
 }
 
 // NewBlockHistoryEstimator returns a new BlockHistoryEstimator that listens
 // for new heads and updates the base gas price dynamically based on the
 // configured percentile of gas prices in that block
 func NewBlockHistoryEstimator(lggr logger.Logger, ethClient FeeEstimatorClient, chaintype chaintype.ChainType, eCfg BlockHistoryEstimatorConfig, bhCfg evmconfig.BlockHistory, chainID *big.Int, l1Oracle rollups.L1Oracle) EvmEstimator {
-	return &BlockHistoryEstimator{
+	l := logger.Sugared(logger.Named(lggr, "BlockHistoryEstimator"))
+	b := &BlockHistoryEstimator{
 		ethClient: ethClient,
 		chainID:   chainID,
 		chaintype: chaintype,
@@ -134,9 +142,21 @@ func NewBlockHistoryEstimator(lggr logger.Logger, ethClient FeeEstimatorClient, 
 		mb:       mailbox.NewSingle[*evmtypes.Head](),
 		wg:       new(sync.WaitGroup),
 		stopCh:   make(chan struct{}),
-		logger:   logger.Sugared(logger.Named(lggr, "BlockHistoryEstimator")),
+		logger:   l,
 		l1Oracle: l1Oracle,
 	}
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_set_gas_price"); err != nil {
+		l.Errorw("Failed to register Beholder gas_updater_set_gas_price gauge", "err", err)
+	} else {
+		b.gasPriceGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_set_tip_cap"); err != nil {
+		l.Errorw("Failed to register Beholder gas_updater_set_tip_cap gauge", "err", err)
+	} else {
+		b.tipCapGauge = g
+	}
+
+	return b
 }
 
 // OnNewLongestChain recalculates and sets global gas price if a sampled new head comes
@@ -539,11 +559,11 @@ func (b *BlockHistoryEstimator) FetchBlocksAndRecalculate(ctx context.Context, h
 		return
 	}
 	b.initialFetch.Store(true)
-	b.Recalculate(head)
+	b.Recalculate(ctx, head)
 }
 
 // Recalculate adds the given heads to the history and recalculates gas price.
-func (b *BlockHistoryEstimator) Recalculate(head *evmtypes.Head) {
+func (b *BlockHistoryEstimator) Recalculate(ctx context.Context, head *evmtypes.Head) {
 	lggr := b.logger.With("head", head)
 
 	blockHistory := b.getBlocks()
@@ -553,13 +573,13 @@ func (b *BlockHistoryEstimator) Recalculate(head *evmtypes.Head) {
 	}
 
 	// Calculate and set the TransactionPercentile gas price and tip cap to use during gas estimation
-	b.calculateGasPriceTipCap(lggr, blockHistory, head)
+	b.calculateGasPriceTipCap(ctx, lggr, blockHistory, head)
 
 	// Calculate and set the CheckInclusionPercentile gas price and tip cap to halt excessive bumping
 	b.calculateMaxPercentileGasPriceTipCap(lggr, blockHistory, head)
 }
 
-func (b *BlockHistoryEstimator) calculateGasPriceTipCap(lggr logger.SugaredLogger, blockHistory []evmtypes.Block, head *evmtypes.Head) {
+func (b *BlockHistoryEstimator) calculateGasPriceTipCap(ctx context.Context, lggr logger.SugaredLogger, blockHistory []evmtypes.Block, head *evmtypes.Head) {
 	percentile := int(b.bhConfig.TransactionPercentile())
 	eip1559 := b.eConfig.EIP1559DynamicFees()
 
@@ -602,7 +622,16 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(lggr logger.SugaredLogge
 		"priceBlocks", numsForPrice,
 	}
 	b.setPercentileGasPrice(percentileGasPrice)
-	promBlockHistoryEstimatorSetGasPrice.WithLabelValues(fmt.Sprintf("%v%%", percentile), b.chainID.String()).Set(float64(percentileGasPrice.Int64()))
+
+	percentileLabel := fmt.Sprintf("%v%%", percentile)
+	chainIDStr := b.chainID.String()
+	promBlockHistoryEstimatorSetGasPrice.WithLabelValues(percentileLabel, chainIDStr).Set(float64(percentileGasPrice.Int64()))
+	if b.gasPriceGauge != nil {
+		b.gasPriceGauge.Record(ctx, float64(percentileGasPrice.Int64()), metric.WithAttributes(
+			attribute.String("evmChainID", chainIDStr),
+			attribute.String("percentile", percentileLabel),
+		))
+	}
 
 	if !eip1559 {
 		lggr.Debugw(fmt.Sprintf("Setting new default GasPrice: %v Gwei", gasPriceGwei), lggrFields...)
@@ -616,7 +645,13 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(lggr logger.SugaredLogge
 	}...)
 	lggr.Debugw(fmt.Sprintf("Setting new default prices, GasPrice: %v Gwei, TipCap: %v Gwei", gasPriceGwei, tipCapGwei), lggrFields...)
 	b.setPercentileTipCap(percentileTipCap)
-	promBlockHistoryEstimatorSetTipCap.WithLabelValues(fmt.Sprintf("%v%%", percentile), b.chainID.String()).Set(float64(percentileTipCap.Int64()))
+	promBlockHistoryEstimatorSetTipCap.WithLabelValues(percentileLabel, chainIDStr).Set(float64(percentileTipCap.Int64()))
+	if b.tipCapGauge != nil {
+		b.tipCapGauge.Record(ctx, float64(percentileTipCap.Int64()), metric.WithAttributes(
+			attribute.String("evmChainID", chainIDStr),
+			attribute.String("percentile", percentileLabel),
+		))
+	}
 }
 
 func (b *BlockHistoryEstimator) calculateMaxPercentileGasPriceTipCap(lggr logger.SugaredLogger, blockHistory []evmtypes.Block, head *evmtypes.Head) {

--- a/pkg/gas/block_history_estimator.go
+++ b/pkg/gas/block_history_estimator.go
@@ -628,7 +628,7 @@ func (b *BlockHistoryEstimator) calculateGasPriceTipCap(ctx context.Context, lgg
 	promBlockHistoryEstimatorSetGasPrice.WithLabelValues(percentileLabel, chainIDStr).Set(float64(percentileGasPrice.Int64()))
 	if b.gasPriceGauge != nil {
 		b.gasPriceGauge.Record(ctx, float64(percentileGasPrice.Int64()), metric.WithAttributes(
-			attribute.String("evmChainID", chainIDStr),
+			attribute.String("chainID", chainIDStr),
 			attribute.String("percentile", percentileLabel),
 		))
 	}

--- a/pkg/gas/block_history_estimator.go
+++ b/pkg/gas/block_history_estimator.go
@@ -105,18 +105,18 @@ func NewBlockHistoryEstimator(lggr logger.Logger, ethClient FeeEstimatorClient, 
 
 // OnNewLongestChain recalculates and sets global gas price if a sampled new head comes
 // in and we are not currently fetching
-func (b *BlockHistoryEstimator) OnNewLongestChain(_ context.Context, head *evmtypes.Head) {
+func (b *BlockHistoryEstimator) OnNewLongestChain(ctx context.Context, head *evmtypes.Head) {
 	// set latest base fee here to avoid potential lag introduced by block delay
 	// it is really important that base fee be as up-to-date as possible
-	b.setLatest(head)
+	b.setLatest(ctx, head)
 	b.mb.Deliver(head)
 }
 
 // setLatest assumes that head won't be mutated
-func (b *BlockHistoryEstimator) setLatest(head *evmtypes.Head) {
+func (b *BlockHistoryEstimator) setLatest(ctx context.Context, head *evmtypes.Head) {
 	// Non-eip1559 blocks don't include base fee
 	if baseFee := head.BaseFeePerGas; baseFee != nil {
-		b.metrics.RecordCurrentBaseFee(float64(baseFee.Int64()))
+		b.metrics.RecordCurrentBaseFee(ctx, float64(baseFee.Int64()))
 	}
 
 	b.logger.Debugw("Set latest block", "blockNum", head.Number, "blockHash", head.Hash, "baseFee", head.BaseFeePerGas, "baseFeeWei", head.BaseFeePerGas.ToInt())
@@ -162,7 +162,7 @@ func (b *BlockHistoryEstimator) Start(ctx context.Context) error {
 			b.logger.Warnw("initial check for latest head failed, head was unexpectedly nil")
 		} else {
 			b.logger.Debugw("Got latest head", "number", latestHead.Number, "blockHash", latestHead.Hash.Hex())
-			b.setLatest(latestHead)
+			b.setLatest(fetchCtx, latestHead)
 			b.FetchBlocksAndRecalculate(fetchCtx, latestHead)
 		}
 

--- a/pkg/gas/block_history_estimator_metrics.go
+++ b/pkg/gas/block_history_estimator_metrics.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
-// Prometheus metrics, exported locally but not sent through Beholder
 var (
 	promBlockHistoryEstimatorAllGasPricePercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "gas_updater_all_gas_price_percentiles",
@@ -46,7 +45,6 @@ var (
 type blockHistoryEstimatorMetrics struct {
 	chainID string
 
-	// otel metrics, exported through Beholder
 	gasPriceGauge                   metric.Float64Gauge
 	tipCapGauge                     metric.Float64Gauge
 	allGasPricePercentilesGauge     metric.Float64Gauge

--- a/pkg/gas/block_history_estimator_metrics.go
+++ b/pkg/gas/block_history_estimator_metrics.go
@@ -1,0 +1,186 @@
+package gas
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+var (
+	promBlockHistoryEstimatorAllGasPricePercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_all_gas_price_percentiles",
+		Help: "Gas price at given percentile",
+	}, []string{"percentile", "evmChainID"})
+	promBlockHistoryEstimatorAllTipCapPercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_all_tip_cap_percentiles",
+		Help: "Tip cap at given percentile",
+	}, []string{"percentile", "evmChainID"})
+	promBlockHistoryEstimatorSetGasPrice = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_set_gas_price",
+		Help: "Gas updater set gas price (in Wei)",
+	}, []string{"percentile", "evmChainID"})
+	promBlockHistoryEstimatorSetTipCap = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_set_tip_cap",
+		Help: "Gas updater set gas tip cap (in Wei)",
+	}, []string{"percentile", "evmChainID"})
+	promBlockHistoryEstimatorCurrentBaseFee = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_current_base_fee",
+		Help: "Gas updater current block base fee in Wei",
+	}, []string{"evmChainID"})
+	promBlockHistoryEstimatorConnectivityFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "block_history_estimator_connectivity_failure_count",
+		Help: "Counter is incremented every time a gas bump is prevented due to a detected network propagation/connectivity issue",
+	}, []string{"evmChainID", "mode"})
+)
+
+// blockHistoryEstimatorMetrics dual-writes to Prometheus and optional Beholder OTel instruments.
+// All Record* methods are safe to call when Beholder instruments are nil (no-op for OTel side).
+type blockHistoryEstimatorMetrics struct {
+	chainID string
+
+	// Prometheus metrics, exported locally but not sent through Beholder
+	promBlockHistoryEstimatorAllGasPricePercentiles   *prometheus.GaugeVec
+	promBlockHistoryEstimatorAllTipCapPercentiles     *prometheus.GaugeVec
+	promBlockHistoryEstimatorSetGasPrice              *prometheus.GaugeVec
+	promBlockHistoryEstimatorSetTipCap                *prometheus.GaugeVec
+	promBlockHistoryEstimatorCurrentBaseFee           *prometheus.GaugeVec
+	promBlockHistoryEstimatorConnectivityFailureCount *prometheus.CounterVec
+
+	// otel metrics, exported through Beholder
+	gasPriceGauge                   metric.Float64Gauge
+	tipCapGauge                     metric.Float64Gauge
+	allGasPricePercentilesGauge     metric.Float64Gauge
+	allTipCapPercentilesGauge       metric.Float64Gauge
+	currentBaseFeeGauge             metric.Float64Gauge
+	connectivityFailureCountCounter metric.Int64Counter
+}
+
+func newBlockHistoryEstimatorMetrics(lggr logger.SugaredLogger, chainID *big.Int) *blockHistoryEstimatorMetrics {
+	m := &blockHistoryEstimatorMetrics{chainID: chainID.String()}
+
+	// prom
+	m.promBlockHistoryEstimatorAllGasPricePercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_all_gas_price_percentiles",
+		Help: "Gas price at given percentile",
+	}, []string{"percentile", "evmChainID"})
+	m.promBlockHistoryEstimatorAllTipCapPercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_all_tip_cap_percentiles",
+		Help: "Tip cap at given percentile",
+	}, []string{"percentile", "evmChainID"})
+	m.promBlockHistoryEstimatorSetGasPrice = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_set_gas_price",
+		Help: "Gas updater set gas price (in Wei)",
+	}, []string{"percentile", "evmChainID"})
+	m.promBlockHistoryEstimatorSetTipCap = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_set_tip_cap",
+		Help: "Gas updater set gas tip cap (in Wei)",
+	}, []string{"percentile", "evmChainID"})
+	m.promBlockHistoryEstimatorCurrentBaseFee = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_updater_current_base_fee",
+		Help: "Gas updater current block base fee in Wei",
+	}, []string{"evmChainID"})
+	m.promBlockHistoryEstimatorConnectivityFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "block_history_estimator_connectivity_failure_count",
+		Help: "Counter is incremented every time a gas bump is prevented due to a detected network propagation/connectivity issue",
+	}, []string{"evmChainID", "mode"})
+
+	// otel
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_set_gas_price"); err != nil {
+		lggr.Errorw("Failed to register Beholder gas_updater_set_gas_price gauge", "err", err)
+	} else {
+		m.gasPriceGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_set_tip_cap"); err != nil {
+		lggr.Errorw("Failed to register Beholder gas_updater_set_tip_cap gauge", "err", err)
+	} else {
+		m.tipCapGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_all_gas_price_percentiles"); err != nil {
+		lggr.Errorw("Failed to register Beholder gas_updater_all_gas_price_percentiles gauge", "err", err)
+	} else {
+		m.allGasPricePercentilesGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_all_tip_cap_percentiles"); err != nil {
+		lggr.Errorw("Failed to register Beholder gas_updater_all_tip_cap_percentiles gauge", "err", err)
+	} else {
+		m.allTipCapPercentilesGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_current_base_fee"); err != nil {
+		lggr.Errorw("Failed to register Beholder gas_updater_current_base_fee gauge", "err", err)
+	} else {
+		m.currentBaseFeeGauge = g
+	}
+	if c, err := beholder.GetMeter().Int64Counter("block_history_estimator_connectivity_failure_count"); err != nil {
+		lggr.Errorw("Failed to register Beholder block_history_estimator_connectivity_failure_count counter", "err", err)
+	} else {
+		m.connectivityFailureCountCounter = c
+	}
+
+	return m
+}
+
+func (m *blockHistoryEstimatorMetrics) RecordSetGasPrice(ctx context.Context, percentileLabel string, value float64) {
+	promBlockHistoryEstimatorSetGasPrice.WithLabelValues(percentileLabel, m.chainID).Set(value)
+	if m.gasPriceGauge != nil {
+		m.gasPriceGauge.Record(ctx, value, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+			attribute.String("percentile", percentileLabel),
+		))
+	}
+}
+
+func (m *blockHistoryEstimatorMetrics) RecordSetTipCap(ctx context.Context, percentileLabel string, value float64) {
+	promBlockHistoryEstimatorSetTipCap.WithLabelValues(percentileLabel, m.chainID).Set(value)
+	if m.tipCapGauge != nil {
+		m.tipCapGauge.Record(ctx, value, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+			attribute.String("percentile", percentileLabel),
+		))
+	}
+}
+
+func (m *blockHistoryEstimatorMetrics) RecordAllGasPricePercentile(ctx context.Context, percentileLabel string, value float64) {
+	promBlockHistoryEstimatorAllGasPricePercentiles.WithLabelValues(percentileLabel, m.chainID).Set(value)
+	if m.allGasPricePercentilesGauge != nil {
+		m.allGasPricePercentilesGauge.Record(ctx, value, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+			attribute.String("percentile", percentileLabel),
+		))
+	}
+}
+
+func (m *blockHistoryEstimatorMetrics) RecordAllTipCapPercentile(ctx context.Context, percentileLabel string, value float64) {
+	promBlockHistoryEstimatorAllTipCapPercentiles.WithLabelValues(percentileLabel, m.chainID).Set(value)
+	if m.allTipCapPercentilesGauge != nil {
+		m.allTipCapPercentilesGauge.Record(ctx, value, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+			attribute.String("percentile", percentileLabel),
+		))
+	}
+}
+
+func (m *blockHistoryEstimatorMetrics) RecordCurrentBaseFee(value float64) {
+	promBlockHistoryEstimatorCurrentBaseFee.WithLabelValues(m.chainID).Set(value)
+	if m.currentBaseFeeGauge != nil {
+		m.currentBaseFeeGauge.Record(context.Background(), value, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+		))
+	}
+}
+
+func (m *blockHistoryEstimatorMetrics) RecordConnectivityFailure(ctx context.Context, mode string) {
+	promBlockHistoryEstimatorConnectivityFailureCount.WithLabelValues(m.chainID, mode).Inc()
+	if m.connectivityFailureCountCounter != nil {
+		m.connectivityFailureCountCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+			attribute.String("mode", mode),
+		))
+	}
+}

--- a/pkg/gas/block_history_estimator_metrics.go
+++ b/pkg/gas/block_history_estimator_metrics.go
@@ -133,10 +133,10 @@ func (m *blockHistoryEstimatorMetrics) RecordAllTipCapPercentile(ctx context.Con
 	}
 }
 
-func (m *blockHistoryEstimatorMetrics) RecordCurrentBaseFee(value float64) {
+func (m *blockHistoryEstimatorMetrics) RecordCurrentBaseFee(ctx context.Context, value float64) {
 	promBlockHistoryEstimatorCurrentBaseFee.WithLabelValues(m.chainID).Set(value)
 	if m.currentBaseFeeGauge != nil {
-		m.currentBaseFeeGauge.Record(context.Background(), value, metric.WithAttributes(
+		m.currentBaseFeeGauge.Record(ctx, value, metric.WithAttributes(
 			attribute.String("chainID", m.chainID),
 		))
 	}

--- a/pkg/gas/block_history_estimator_metrics.go
+++ b/pkg/gas/block_history_estimator_metrics.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
+// Prometheus metrics, exported locally but not sent through Beholder
 var (
 	promBlockHistoryEstimatorAllGasPricePercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "gas_updater_all_gas_price_percentiles",
@@ -45,14 +46,6 @@ var (
 type blockHistoryEstimatorMetrics struct {
 	chainID string
 
-	// Prometheus metrics, exported locally but not sent through Beholder
-	promBlockHistoryEstimatorAllGasPricePercentiles   *prometheus.GaugeVec
-	promBlockHistoryEstimatorAllTipCapPercentiles     *prometheus.GaugeVec
-	promBlockHistoryEstimatorSetGasPrice              *prometheus.GaugeVec
-	promBlockHistoryEstimatorSetTipCap                *prometheus.GaugeVec
-	promBlockHistoryEstimatorCurrentBaseFee           *prometheus.GaugeVec
-	promBlockHistoryEstimatorConnectivityFailureCount *prometheus.CounterVec
-
 	// otel metrics, exported through Beholder
 	gasPriceGauge                   metric.Float64Gauge
 	tipCapGauge                     metric.Float64Gauge
@@ -64,32 +57,6 @@ type blockHistoryEstimatorMetrics struct {
 
 func newBlockHistoryEstimatorMetrics(lggr logger.SugaredLogger, chainID *big.Int) *blockHistoryEstimatorMetrics {
 	m := &blockHistoryEstimatorMetrics{chainID: chainID.String()}
-
-	// prom
-	m.promBlockHistoryEstimatorAllGasPricePercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_all_gas_price_percentiles",
-		Help: "Gas price at given percentile",
-	}, []string{"percentile", "evmChainID"})
-	m.promBlockHistoryEstimatorAllTipCapPercentiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_all_tip_cap_percentiles",
-		Help: "Tip cap at given percentile",
-	}, []string{"percentile", "evmChainID"})
-	m.promBlockHistoryEstimatorSetGasPrice = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_set_gas_price",
-		Help: "Gas updater set gas price (in Wei)",
-	}, []string{"percentile", "evmChainID"})
-	m.promBlockHistoryEstimatorSetTipCap = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_set_tip_cap",
-		Help: "Gas updater set gas tip cap (in Wei)",
-	}, []string{"percentile", "evmChainID"})
-	m.promBlockHistoryEstimatorCurrentBaseFee = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_updater_current_base_fee",
-		Help: "Gas updater current block base fee in Wei",
-	}, []string{"evmChainID"})
-	m.promBlockHistoryEstimatorConnectivityFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "block_history_estimator_connectivity_failure_count",
-		Help: "Counter is incremented every time a gas bump is prevented due to a detected network propagation/connectivity issue",
-	}, []string{"evmChainID", "mode"})
 
 	// otel
 	if g, err := beholder.GetMeter().Float64Gauge("gas_updater_set_gas_price"); err != nil {

--- a/pkg/gas/block_history_estimator_test.go
+++ b/pkg/gas/block_history_estimator_test.go
@@ -854,15 +854,15 @@ func TestBlockHistoryEstimator_Recalculate_NoEIP1559(t *testing.T) {
 
 		blocks := []evmtypes.Block{}
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		blocks = []evmtypes.Block{{}}
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		blocks = []evmtypes.Block{{Transactions: []evmtypes.Transaction{}}}
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 	})
 
 	t.Run("sets gas price to EVM.GasEstimator.PriceMax if the calculation would otherwise exceed it", func(t *testing.T) {
@@ -895,7 +895,7 @@ func TestBlockHistoryEstimator_Recalculate_NoEIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		price := gas.GetGasPrice(bhe)
 		require.Equal(t, maxGasPrice, price)
@@ -931,7 +931,7 @@ func TestBlockHistoryEstimator_Recalculate_NoEIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		price := gas.GetGasPrice(bhe)
 		require.Equal(t, minGasPrice, price)
@@ -978,7 +978,7 @@ func TestBlockHistoryEstimator_Recalculate_NoEIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(2))
+		bhe.Recalculate(t.Context(), testutils.Head(2))
 
 		price := gas.GetGasPrice(bhe)
 		require.Equal(t, assets.NewWeiI(70), price)
@@ -1012,7 +1012,7 @@ func TestBlockHistoryEstimator_Recalculate_NoEIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(0))
+		bhe.Recalculate(t.Context(), testutils.Head(0))
 
 		price := gas.GetGasPrice(bhe)
 		require.Equal(t, assets.NewWeiI(25), price)
@@ -1046,21 +1046,21 @@ func TestBlockHistoryEstimator_Recalculate_NoEIP1559(t *testing.T) {
 		gas.SetRollingBlockHistory(bhe, blocks)
 
 		// chainType is not set - GasEstimator should not ignore zero priced transactions and instead default to PriceMin==11
-		bhe.Recalculate(testutils.Head(0))
+		bhe.Recalculate(t.Context(), testutils.Head(0))
 		require.Equal(t, assets.NewWeiI(11), gas.GetGasPrice(bhe))
 
 		// Set chainType to Gnosis - GasEstimator should now ignore zero priced transactions
 		ibhe = newBlockHistoryEstimator(t, ethClient, chaintype.ChainGnosis, geCfg, bhCfg, l1Oracle)
 		bhe = gas.BlockHistoryEstimatorFromInterface(ibhe)
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(0))
+		bhe.Recalculate(t.Context(), testutils.Head(0))
 		require.Equal(t, assets.NewWeiI(80), gas.GetGasPrice(bhe))
 
 		// And for X Layer
 		ibhe = newBlockHistoryEstimator(t, ethClient, chaintype.ChainXLayer, geCfg, bhCfg, l1Oracle)
 		bhe = gas.BlockHistoryEstimatorFromInterface(ibhe)
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(0))
+		bhe.Recalculate(t.Context(), testutils.Head(0))
 		require.Equal(t, assets.NewWeiI(80), gas.GetGasPrice(bhe))
 	})
 
@@ -1108,7 +1108,7 @@ func TestBlockHistoryEstimator_Recalculate_NoEIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(0))
+		bhe.Recalculate(t.Context(), testutils.Head(0))
 
 		price := gas.GetGasPrice(bhe)
 		require.Equal(t, reasonablyHugeGasPrice, price)
@@ -1145,7 +1145,7 @@ func TestBlockHistoryEstimator_Recalculate_NoEIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(0))
+		bhe.Recalculate(t.Context(), testutils.Head(0))
 
 		price := gas.GetGasPrice(bhe)
 		require.Equal(t, assets.NewWeiI(100), price)
@@ -1176,27 +1176,27 @@ func TestBlockHistoryEstimator_Recalculate_EIP1559(t *testing.T) {
 
 		blocks := []evmtypes.Block{}
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		blocks = []evmtypes.Block{{}} // No base fee (doesn't crash)
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		blocks = []evmtypes.Block{newBlockWithBaseFee()}
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		empty := newBlockWithBaseFee()
 		empty.Transactions = []evmtypes.Transaction{}
 		blocks = []evmtypes.Block{empty}
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		withOnlyLegacyTransactions := newBlockWithBaseFee()
 		withOnlyLegacyTransactions.Transactions = legacyTransactionsFromGasPrices(9001)
 		blocks = []evmtypes.Block{withOnlyLegacyTransactions}
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 	})
 
 	t.Run("does not set tip higher than EVM.GasEstimator.PriceMax", func(t *testing.T) {
@@ -1232,7 +1232,7 @@ func TestBlockHistoryEstimator_Recalculate_EIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		tipCap := gas.GetTipCap(bhe)
 		require.Equal(t, tipCap.Int64(), maxGasPrice.Int64())
@@ -1271,7 +1271,7 @@ func TestBlockHistoryEstimator_Recalculate_EIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(1))
+		bhe.Recalculate(t.Context(), testutils.Head(1))
 
 		price := gas.GetTipCap(bhe)
 		require.Equal(t, assets.NewWeiI(10), price)
@@ -1320,7 +1320,7 @@ func TestBlockHistoryEstimator_Recalculate_EIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(2))
+		bhe.Recalculate(t.Context(), testutils.Head(2))
 
 		price := gas.GetTipCap(bhe)
 		require.Equal(t, assets.NewWeiI(60), price)
@@ -1356,7 +1356,7 @@ func TestBlockHistoryEstimator_Recalculate_EIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(0))
+		bhe.Recalculate(t.Context(), testutils.Head(0))
 
 		price := gas.GetTipCap(bhe)
 		assert.Equal(t, assets.NewWeiI(1), price)
@@ -1393,7 +1393,7 @@ func TestBlockHistoryEstimator_Recalculate_EIP1559(t *testing.T) {
 
 		gas.SetRollingBlockHistory(bhe, blocks)
 
-		bhe.Recalculate(testutils.Head(0))
+		bhe.Recalculate(t.Context(), testutils.Head(0))
 
 		price := gas.GetTipCap(bhe)
 		require.Equal(t, assets.NewWeiI(0), price)
@@ -1945,7 +1945,7 @@ func TestBlockHistoryEstimator_GetLegacyGas(t *testing.T) {
 	}
 
 	gas.SetRollingBlockHistory(bhe, blocks)
-	bhe.Recalculate(testutils.Head(1))
+	bhe.Recalculate(t.Context(), testutils.Head(1))
 	gas.SimulateStart(t, bhe)
 
 	t.Run("if gas price is lower than global max and user specified max gas price", func(t *testing.T) {
@@ -1973,7 +1973,7 @@ func TestBlockHistoryEstimator_GetLegacyGas(t *testing.T) {
 
 	bhe = newBlockHistoryEstimator(t, nil, defaultChainType, geCfg, bhCfg, l1Oracle)
 	gas.SetRollingBlockHistory(bhe, blocks)
-	bhe.Recalculate(testutils.Head(1))
+	bhe.Recalculate(t.Context(), testutils.Head(1))
 	gas.SimulateStart(t, bhe)
 
 	t.Run("if gas price is higher than global max", func(t *testing.T) {
@@ -2067,7 +2067,7 @@ func TestBlockHistoryEstimator_GetMaxLegacyGas(t *testing.T) {
 		}
 
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(3))
+		bhe.Recalculate(t.Context(), testutils.Head(3))
 		gas.SimulateStart(t, bhe)
 
 		// Set initialFetch to true to simulate successful start
@@ -2170,7 +2170,7 @@ func TestBlockHistoryEstimator_GetMaxDynamicFee(t *testing.T) {
 		}
 
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(3))
+		bhe.Recalculate(t.Context(), testutils.Head(3))
 		gas.SimulateStart(t, bhe)
 		gas.SetInitialFetch(bhe, true)
 
@@ -2208,7 +2208,7 @@ func TestBlockHistoryEstimator_GetMaxDynamicFee(t *testing.T) {
 		}
 
 		gas.SetRollingBlockHistory(bhe, blocks)
-		bhe.Recalculate(testutils.Head(3))
+		bhe.Recalculate(t.Context(), testutils.Head(3))
 		gas.SimulateStart(t, bhe)
 		gas.SetInitialFetch(bhe, true)
 
@@ -2252,7 +2252,7 @@ func TestBlockHistoryEstimator_GetMaxDynamicFee(t *testing.T) {
 		gas.SetRollingBlockHistory(bhe, blocks)
 		h := testutils.Head(3)
 		h.BaseFeePerGas = assets.NewWeiI(100000)
-		bhe.Recalculate(h)
+		bhe.Recalculate(t.Context(), h)
 		gas.SimulateStart(t, bhe)
 		gas.SetInitialFetch(bhe, true)
 		bhe.OnNewLongestChain(t.Context(), h)
@@ -2418,7 +2418,7 @@ func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 	}
 	gas.SetRollingBlockHistory(bhe, blocks)
 
-	bhe.Recalculate(testutils.Head(1))
+	bhe.Recalculate(t.Context(), testutils.Head(1))
 	gas.SimulateStart(t, bhe)
 
 	t.Run("if estimator is missing base fee and gas bumping is enabled", func(t *testing.T) {
@@ -2557,7 +2557,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 		Transactions: legacyTransactionsFromGasPrices(90, 100),
 	}
 	gas.SetRollingBlockHistory(bhe, []evmtypes.Block{b0, b1, b2, b3})
-	bhe.Recalculate(testutils.Head(3))
+	bhe.Recalculate(t.Context(), testutils.Head(3))
 
 	t.Run("skips halt bumping check if attempts is nil or empty", func(t *testing.T) {
 		err := bhe.HaltBumping(nil)
@@ -2621,7 +2621,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 		t.Run("passes check if all attempt gas prices are lower than or equal to percentile price", func(t *testing.T) {
 			bhCfg.CheckInclusionBlocksF = 3
 			bhCfg.CheckInclusionPercentileF = 80 // percentile price is 7 wei
-			bhe.Recalculate(testutils.Head(3))
+			bhe.Recalculate(t.Context(), testutils.Head(3))
 
 			err := bhe.HaltBumping(attempts)
 			require.NoError(t, err)
@@ -2629,7 +2629,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 		t.Run("fails check if any attempt price is higher than percentile price", func(t *testing.T) {
 			bhCfg.CheckInclusionBlocksF = 3
 			bhCfg.CheckInclusionPercentileF = 40 // percentile price is 5 wei
-			bhe.Recalculate(testutils.Head(3))
+			bhe.Recalculate(t.Context(), testutils.Head(3))
 
 			err := bhe.HaltBumping(attempts)
 			require.Error(t, err)
@@ -2655,7 +2655,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 		t.Run("passes check if both transactions are ok", func(t *testing.T) {
 			bhCfg.CheckInclusionBlocksF = 1
 			bhCfg.CheckInclusionPercentileF = 90 // percentile price is 5 wei
-			bhe.Recalculate(testutils.Head(3))
+			bhe.Recalculate(t.Context(), testutils.Head(3))
 
 			err := bhe.HaltBumping(attempts)
 			require.NoError(t, err)
@@ -2663,7 +2663,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 		t.Run("fails check if legacy transaction fails", func(t *testing.T) {
 			bhCfg.CheckInclusionBlocksF = 1
 			bhCfg.CheckInclusionPercentileF = 60
-			bhe.Recalculate(testutils.Head(3))
+			bhe.Recalculate(t.Context(), testutils.Head(3))
 
 			err := bhe.HaltBumping(attempts)
 			require.Error(t, err)
@@ -2681,7 +2681,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 			geCfg.TipCapMinF = assets.NewWeiI(1)
 			bhCfg.CheckInclusionBlocksF = 1
 			bhCfg.CheckInclusionPercentileF = 60
-			bhe.Recalculate(testutils.Head(3))
+			bhe.Recalculate(t.Context(), testutils.Head(3))
 
 			err := bhe.HaltBumping(attempts)
 			require.Error(t, err)
@@ -2731,7 +2731,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 		t.Run("passes check if 90th percentile price higher than highest transaction tip cap", func(t *testing.T) {
 			bhCfg.CheckInclusionBlocksF = 3
 			bhCfg.CheckInclusionPercentileF = 80
-			bhe.Recalculate(testutils.Head(3))
+			bhe.Recalculate(t.Context(), testutils.Head(3))
 
 			err := bhe.HaltBumping(attempts)
 			require.NoError(t, err)
@@ -2740,7 +2740,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 		t.Run("fails check if percentile tip cap higher than any transaction tip cap, and base fee higher than the block base fee", func(t *testing.T) {
 			bhCfg.CheckInclusionBlocksF = 3
 			bhCfg.CheckInclusionPercentileF = 20
-			bhe.Recalculate(testutils.Head(3))
+			bhe.Recalculate(t.Context(), testutils.Head(3))
 
 			err := bhe.HaltBumping(attempts)
 			require.Error(t, err)
@@ -2749,7 +2749,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 
 			bhCfg.CheckInclusionBlocksF = 3
 			bhCfg.CheckInclusionPercentileF = 2
-			bhe.Recalculate(testutils.Head(3))
+			bhe.Recalculate(t.Context(), testutils.Head(3))
 
 			err = bhe.HaltBumping(attempts)
 			require.Error(t, err)
@@ -2760,7 +2760,7 @@ func TestBlockHistoryEstimator_HaltBumping(t *testing.T) {
 		t.Run("passes check if, for at least one block, feecap < tipcap+basefee, even if percentile is not reached", func(t *testing.T) {
 			bhCfg.CheckInclusionBlocksF = 3
 			bhCfg.CheckInclusionPercentileF = 5
-			bhe.Recalculate(testutils.Head(3))
+			bhe.Recalculate(t.Context(), testutils.Head(3))
 
 			attempts = []gas.EvmPriorAttempt{
 				{TxType: 0x2, TxHash: NewEvmHash(), DynamicFee: gas.DynamicFee{GasFeeCap: assets.NewWeiI(4), GasTipCap: assets.NewWeiI(7)}, BroadcastBeforeBlockNum: ptr(int64(1))},

--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -22,34 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas/rollups"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-framework/chains/fees"
-)
-
-// metrics are thread safe
-var (
-	promFeeHistoryEstimatorGasPrice = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gas_price_updater",
-		Help: "Sets latest gas price (in Wei)",
-	},
-		[]string{"evmChainID"},
-	)
-	promFeeHistoryEstimatorBaseFee = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "base_fee_updater",
-		Help: "Sets latest BaseFee (in Wei)",
-	},
-		[]string{"evmChainID"},
-	)
-	promFeeHistoryEstimatorMaxPriorityFeePerGas = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "max_priority_fee_per_gas_updater",
-		Help: "Sets latest MaxPriorityFeePerGas (in Wei)",
-	},
-		[]string{"evmChainID"},
-	)
-	promFeeHistoryEstimatorMaxFeePerGas = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "max_fee_per_gas_updater",
-		Help: "Sets latest MaxFeePerGas (in Wei)",
-	},
-		[]string{"evmChainID"},
-	)
 )
 
 const (
@@ -94,18 +64,22 @@ type FeeHistoryEstimator struct {
 
 	l1Oracle rollups.L1Oracle
 
+	metrics *feeHistoryEstimatorMetrics
+
 	wg        *sync.WaitGroup
 	stopCh    services.StopChan
 	refreshCh chan struct{}
 }
 
 func NewFeeHistoryEstimator(lggr logger.Logger, client feeHistoryEstimatorClient, cfg FeeHistoryEstimatorConfig, chainID *big.Int, l1Oracle rollups.L1Oracle) *FeeHistoryEstimator {
+	l := logger.Sugared(logger.Named(lggr, "FeeHistoryEstimator"))
 	return &FeeHistoryEstimator{
 		client:    client,
-		logger:    logger.Named(lggr, "FeeHistoryEstimator"),
+		logger:    l,
 		config:    cfg,
 		chainID:   chainID,
 		l1Oracle:  l1Oracle,
+		metrics:   newFeeHistoryEstimatorMetrics(l, chainID),
 		wg:        new(sync.WaitGroup),
 		stopCh:    make(chan struct{}),
 		refreshCh: make(chan struct{}),
@@ -195,7 +169,7 @@ func (f *FeeHistoryEstimator) RefreshGasPrice() (*assets.Wei, error) {
 		return nil, err
 	}
 
-	promFeeHistoryEstimatorGasPrice.WithLabelValues(f.chainID.String()).Set(float64(gasPrice.Int64()))
+	f.metrics.RecordGasPrice(ctx, float64(gasPrice.Int64()))
 
 	gasPriceWei := assets.NewWei(gasPrice)
 
@@ -308,9 +282,9 @@ func (f *FeeHistoryEstimator) RefreshDynamicPrice() error {
 	f.nextBaseFee = nextBaseFee
 	f.nextBaseFeeMu.Unlock()
 
-	promFeeHistoryEstimatorBaseFee.WithLabelValues(f.chainID.String()).Set(float64(nextBaseFee.Int64()))
-	promFeeHistoryEstimatorMaxPriorityFeePerGas.WithLabelValues(f.chainID.String()).Set(float64(maxPriorityFeePerGas.Int64()))
-	promFeeHistoryEstimatorMaxFeePerGas.WithLabelValues(f.chainID.String()).Set(float64(maxFeePerGas.Int64()))
+	f.metrics.RecordBaseFee(ctx, float64(nextBaseFee.Int64()))
+	f.metrics.RecordMaxPriorityFeePerGas(ctx, float64(maxPriorityFeePerGas.Int64()))
+	f.metrics.RecordMaxFeePerGas(ctx, float64(maxFeePerGas.Int64()))
 
 	f.logger.Debugf("Fetched new dynamic prices, nextBlock#: %v - oldestBlock#: %v - nextBaseFee: %v - maxFeePerGas: %v - maxPriorityFeePerGas: %v - maxPriorityFeeThreshold: %v",
 		nextBlock, feeHistory.OldestBlock, nextBaseFee, maxFeePerGas, maxPriorityFeePerGas, priorityFeeThresholdWei)

--- a/pkg/gas/fee_history_estimator_metrics.go
+++ b/pkg/gas/fee_history_estimator_metrics.go
@@ -1,0 +1,105 @@
+package gas
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+var (
+	promFeeHistoryEstimatorGasPrice = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "gas_price_updater",
+		Help: "Sets latest gas price (in Wei)",
+	}, []string{"evmChainID"})
+	promFeeHistoryEstimatorBaseFee = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "base_fee_updater",
+		Help: "Sets latest BaseFee (in Wei)",
+	}, []string{"evmChainID"})
+	promFeeHistoryEstimatorMaxPriorityFeePerGas = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "max_priority_fee_per_gas_updater",
+		Help: "Sets latest MaxPriorityFeePerGas (in Wei)",
+	}, []string{"evmChainID"})
+	promFeeHistoryEstimatorMaxFeePerGas = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "max_fee_per_gas_updater",
+		Help: "Sets latest MaxFeePerGas (in Wei)",
+	}, []string{"evmChainID"})
+)
+
+// feeHistoryEstimatorMetrics dual-writes to Prometheus and optional Beholder OTel instruments.
+// All Record* methods are safe to call when Beholder instruments are nil (no-op for OTel side).
+type feeHistoryEstimatorMetrics struct {
+	chainID string
+
+	gasPriceGauge             metric.Float64Gauge
+	baseFeeGauge              metric.Float64Gauge
+	maxPriorityFeePerGasGauge metric.Float64Gauge
+	maxFeePerGasGauge         metric.Float64Gauge
+}
+
+func newFeeHistoryEstimatorMetrics(lggr logger.SugaredLogger, chainID *big.Int) *feeHistoryEstimatorMetrics {
+	m := &feeHistoryEstimatorMetrics{chainID: chainID.String()}
+	if g, err := beholder.GetMeter().Float64Gauge("gas_price_updater"); err != nil {
+		lggr.Errorw("Failed to register Beholder gas_price_updater gauge", "err", err)
+	} else {
+		m.gasPriceGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("base_fee_updater"); err != nil {
+		lggr.Errorw("Failed to register Beholder base_fee_updater gauge", "err", err)
+	} else {
+		m.baseFeeGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("max_priority_fee_per_gas_updater"); err != nil {
+		lggr.Errorw("Failed to register Beholder max_priority_fee_per_gas_updater gauge", "err", err)
+	} else {
+		m.maxPriorityFeePerGasGauge = g
+	}
+	if g, err := beholder.GetMeter().Float64Gauge("max_fee_per_gas_updater"); err != nil {
+		lggr.Errorw("Failed to register Beholder max_fee_per_gas_updater gauge", "err", err)
+	} else {
+		m.maxFeePerGasGauge = g
+	}
+	return m
+}
+
+func (m *feeHistoryEstimatorMetrics) RecordGasPrice(ctx context.Context, value float64) {
+	promFeeHistoryEstimatorGasPrice.WithLabelValues(m.chainID).Set(value)
+	if m.gasPriceGauge != nil {
+		m.gasPriceGauge.Record(ctx, value, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+		))
+	}
+}
+
+func (m *feeHistoryEstimatorMetrics) RecordBaseFee(ctx context.Context, value float64) {
+	promFeeHistoryEstimatorBaseFee.WithLabelValues(m.chainID).Set(value)
+	if m.baseFeeGauge != nil {
+		m.baseFeeGauge.Record(ctx, value, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+		))
+	}
+}
+
+func (m *feeHistoryEstimatorMetrics) RecordMaxPriorityFeePerGas(ctx context.Context, value float64) {
+	promFeeHistoryEstimatorMaxPriorityFeePerGas.WithLabelValues(m.chainID).Set(value)
+	if m.maxPriorityFeePerGasGauge != nil {
+		m.maxPriorityFeePerGasGauge.Record(ctx, value, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+		))
+	}
+}
+
+func (m *feeHistoryEstimatorMetrics) RecordMaxFeePerGas(ctx context.Context, value float64) {
+	promFeeHistoryEstimatorMaxFeePerGas.WithLabelValues(m.chainID).Set(value)
+	if m.maxFeePerGasGauge != nil {
+		m.maxFeePerGasGauge.Record(ctx, value, metric.WithAttributes(
+			attribute.String("chainID", m.chainID),
+		))
+	}
+}


### PR DESCRIPTION
## What 
Add otel metrics for all `block_history_estimator` and `fee_history_estimator` metrics, next to the existing Prom metrics.

## Why
To make it easier to detect gas-related issues. 

## Supports
https://github.com/smartcontractkit/chainlink/pull/21604