### PR TITLE
Sepearte SVR Gas Config 

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -393,6 +393,7 @@ DualBroadcast = false # Example
 ReadRequestsToMultipleNodes = false # Example
 Bundles = false # Example
 FastlaneAuctionRequestTimeout = '5s' # Example
+TransactionPercentile = 60 # Example
 ```
 
 
@@ -437,6 +438,16 @@ Bundles enables sending bundles for auctioning (not compatible with all OFAs).
 FastlaneAuctionRequestTimeout = '5s' # Example
 ```
 FastlaneAuctionRequestTimeout configures the HTTP request timeout for Fastlane Atlas auction requests. Defaults to 5s if not set.
+
+### TransactionPercentile
+```toml
+TransactionPercentile = 60 # Example
+```
+TransactionPercentile overrides the RewardPercentile used by the TxM v2 FeeHistory estimator.
+TxM v2 always uses a FeeHistory estimator regardless of the GasEstimator.Mode setting.
+If not set, falls back to GasEstimator.BlockHistory.TransactionPercentile.
+Note: this setting has no effect when EIP1559DynamicFees is false, because in legacy mode
+the FeeHistory estimator uses eth_gasPrice which does not use percentiles.
 
 ## BalanceMonitor
 ```toml

--- a/pkg/chains/legacyevm/chain.go
+++ b/pkg/chains/legacyevm/chain.go
@@ -273,7 +273,7 @@ func newChain(cfg *config.ChainScoped, nodes []*toml.Node, opts ChainRelayOpts, 
 	} else if !cfg.EVM().Transactions().Enabled() {
 		txm = &txmgr.NullTxManager{ErrMsg: fmt.Sprintf("TXM disabled for chain %d", chainID)}
 	} else {
-		txm, err = newEvmTxm(opts.DS, cfg.EVM(), opts.DatabaseConfig, opts.ListenerConfig, cl, l, logPoller, opts, headTracker, gasEstimator)
+		txm, err = newEvmTxm(opts.DS, cfg.EVM(), opts.DatabaseConfig, opts.ListenerConfig, cl, l, logPoller, opts, headTracker, gasEstimator, clientsByChainID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to instantiate EvmTxm for chain with ID %s: %w", chainID, err)
 		}

--- a/pkg/chains/legacyevm/evm_txm.go
+++ b/pkg/chains/legacyevm/evm_txm.go
@@ -27,6 +27,7 @@ func newEvmTxm(
 	opts ChainRelayOpts,
 	headTracker evmheads.Tracker,
 	estimator gas.EvmFeeEstimator,
+	clientsByChainID map[string]rollups.DAClient,
 ) (txm txmgr.TxManager,
 	err error,
 ) {
@@ -53,6 +54,12 @@ func newEvmTxm(
 			*txV2Cfg.DualBroadcast() && txV2Cfg.CustomURL() != nil
 
 		if txV2Cfg.Enabled() {
+			// TxM v2 gets its own FeeHistory estimator with a potentially different TransactionPercentile,
+			// allowing SVR transactions to target a different gas price aggressiveness than primary transactions.
+			txmV2Estimator, estErr := newTxmV2FeeHistoryEstimator(cfg, client, lggr, clientsByChainID)
+			if estErr != nil {
+				return nil, fmt.Errorf("failed to initialize TxM v2 FeeHistory estimator: %w", estErr)
+			}
 			txmv2, err = txmgr.NewTxmV2(
 				ds,
 				cfg,
@@ -63,7 +70,7 @@ func newEvmTxm(
 				lggr,
 				logPoller,
 				opts.KeyStore,
-				estimator,
+				txmV2Estimator,
 				cfg.GasEstimator(),
 			)
 			if err != nil {
@@ -123,4 +130,50 @@ func newGasEstimator(
 		estimator = opts.GenGasEstimator(chainID)
 	}
 	return
+}
+
+// newTxmV2FeeHistoryEstimator creates a FeeHistory estimator for TxM v2.
+// It derives all config from the shared GasEstimator config, except RewardPercentile
+// which is overridden by TransactionManagerV2.TransactionPercentile if set.
+func newTxmV2FeeHistoryEstimator(
+	cfg evmconfig.EVM,
+	client evmclient.Client,
+	lggr logger.Logger,
+	clientsByChainID map[string]rollups.DAClient,
+) (gas.EvmFeeEstimator, error) {
+	lggr = logger.Named(lggr, "Txm")
+	chainID := cfg.ChainID()
+	geCfg := cfg.GasEstimator()
+	txmV2Cfg := cfg.Transactions().TransactionManagerV2()
+
+	// Determine the RewardPercentile: use TxM v2 override if set, otherwise fall back to the shared config
+	rewardPercentile := float64(geCfg.BlockHistory().TransactionPercentile())
+	if txmV2Cfg.TransactionPercentile() != nil {
+		rewardPercentile = float64(*txmV2Cfg.TransactionPercentile())
+	}
+
+	l1Oracle, err := rollups.NewL1GasOracle(lggr, client, cfg.ChainType(), geCfg.DAOracle(), clientsByChainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize L1 oracle for TxM v2: %w", err)
+	}
+
+	fhCfg := gas.FeeHistoryEstimatorConfig{
+		BumpPercent:      geCfg.BumpPercent(),
+		CacheTimeout:     geCfg.FeeHistory().CacheTimeout(),
+		EIP1559:          geCfg.EIP1559DynamicFees(),
+		BlockHistorySize: uint64(geCfg.BlockHistory().BlockHistorySize()),
+		RewardPercentile: rewardPercentile,
+	}
+
+	lggr.Infow("Initializing TxM v2 FeeHistory gas estimator",
+		"rewardPercentile", rewardPercentile,
+		"blockHistorySize", fhCfg.BlockHistorySize,
+		"eip1559DynamicFees", fhCfg.EIP1559,
+		"bumpPercent", fhCfg.BumpPercent,
+	)
+
+	newEstimator := func(l logger.Logger) gas.EvmEstimator {
+		return gas.NewFeeHistoryEstimator(lggr, client, fhCfg, chainID, l1Oracle)
+	}
+	return gas.NewEvmFeeEstimator(lggr, newEstimator, geCfg.EIP1559DynamicFees(), geCfg, client), nil
 }

--- a/pkg/chains/legacyevm/evm_txm.go
+++ b/pkg/chains/legacyevm/evm_txm.go
@@ -119,7 +119,7 @@ func newGasEstimator(
 	opts ChainRelayOpts,
 	clientsByChainID map[string]rollups.DAClient,
 ) (estimator gas.EvmFeeEstimator, err error) {
-	lggr = logger.Named(lggr, "Txm")
+	lggr = logger.Named(lggr, "GasEstimator")
 	chainID := cfg.ChainID()
 	// build estimator from factory
 	if opts.GenGasEstimator == nil {
@@ -141,7 +141,7 @@ func newTxmV2FeeHistoryEstimator(
 	lggr logger.Logger,
 	clientsByChainID map[string]rollups.DAClient,
 ) (gas.EvmFeeEstimator, error) {
-	lggr = logger.Named(lggr, "Txm")
+	lggr = logger.Named(lggr, "TxmV2FeeHistoryEstimator")
 	chainID := cfg.ChainID()
 	geCfg := cfg.GasEstimator()
 	txmV2Cfg := cfg.Transactions().TransactionManagerV2()

--- a/pkg/chains/legacyevm/evm_txm.go
+++ b/pkg/chains/legacyevm/evm_txm.go
@@ -152,6 +152,16 @@ func newTxmV2FeeHistoryEstimator(
 		rewardPercentile = float64(*txmV2Cfg.TransactionPercentile())
 	}
 
+	// Validate that RewardPercentile doesn't exceed ConnectivityPercentile (85) when using EIP-1559.
+	// FeeHistoryEstimator.Start() will reject this, but catching it here gives a clearer config error —
+	// especially on the fallback path where BlockHistory.TransactionPercentile (which can be >85) is used.
+	if geCfg.EIP1559DynamicFees() && rewardPercentile > gas.ConnectivityPercentile {
+		return nil, fmt.Errorf(
+			"TxM v2 FeeHistory estimator RewardPercentile (%.0f) exceeds maximum allowed ConnectivityPercentile (%d) for EIP-1559 mode; "+
+				"set [EVM.Transactions.TransactionManagerV2] TransactionPercentile to a value <= %d",
+			rewardPercentile, gas.ConnectivityPercentile, gas.ConnectivityPercentile)
+	}
+
 	l1Oracle, err := rollups.NewL1GasOracle(lggr, client, cfg.ChainType(), geCfg.DAOracle(), clientsByChainID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize L1 oracle for TxM v2: %w", err)

--- a/pkg/config/chain_scoped_transactions.go
+++ b/pkg/config/chain_scoped_transactions.go
@@ -80,6 +80,10 @@ func (t *transactionManagerV2Config) FastlaneAuctionRequestTimeout() *time.Durat
 	return &d
 }
 
+func (t *transactionManagerV2Config) TransactionPercentile() *uint16 {
+	return t.c.TransactionPercentile
+}
+
 func (t *transactionsConfig) AutoPurge() AutoPurgeConfig {
 	return &autoPurgeConfig{c: t.c.AutoPurge}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,6 +137,9 @@ type TransactionManagerV2 interface {
 	ReadRequestsToMultipleNodes() *bool
 	Bundles() *bool
 	FastlaneAuctionRequestTimeout() *time.Duration
+	// TransactionPercentile returns the TxM v2-specific percentile override for the FeeHistory estimator.
+	// Returns nil if not set, meaning the shared GasEstimator.BlockHistory.TransactionPercentile should be used.
+	TransactionPercentile() *uint16
 }
 
 type GasEstimator interface {

--- a/pkg/config/toml/config.go
+++ b/pkg/config/toml/config.go
@@ -593,6 +593,10 @@ type TransactionManagerV2Config struct {
 	ReadRequestsToMultipleNodes   *bool                  `toml:",omitempty"`
 	Bundles                       *bool                  `toml:",omitempty"`
 	FastlaneAuctionRequestTimeout *commonconfig.Duration `toml:",omitempty"`
+	// TransactionPercentile overrides the RewardPercentile used by TxM v2's FeeHistory estimator.
+	// When nil, falls back to GasEstimator.BlockHistory.TransactionPercentile.
+	// Has no effect when EIP1559DynamicFees is false (legacy mode uses eth_gasPrice, not percentiles).
+	TransactionPercentile *uint16 `toml:",omitempty"`
 }
 
 func (t *TransactionManagerV2Config) setFrom(f *TransactionManagerV2Config) {
@@ -616,6 +620,9 @@ func (t *TransactionManagerV2Config) setFrom(f *TransactionManagerV2Config) {
 	}
 	if v := f.FastlaneAuctionRequestTimeout; v != nil {
 		t.FastlaneAuctionRequestTimeout = f.FastlaneAuctionRequestTimeout
+	}
+	if v := f.TransactionPercentile; v != nil {
+		t.TransactionPercentile = f.TransactionPercentile
 	}
 }
 

--- a/pkg/config/toml/config_test.go
+++ b/pkg/config/toml/config_test.go
@@ -67,6 +67,7 @@ func TestDefaults_fieldsNotNil(t *testing.T) {
 	unknown.Transactions.TransactionManagerV2.ReadRequestsToMultipleNodes = ptr(false)
 	unknown.Transactions.TransactionManagerV2.Bundles = ptr(false)
 	unknown.Transactions.TransactionManagerV2.FastlaneAuctionRequestTimeout = new(config.Duration)
+	unknown.Transactions.TransactionManagerV2.TransactionPercentile = ptr[uint16](0)
 	unknown.Transactions.AutoPurge.Threshold = ptr(uint32(0))
 	unknown.Transactions.AutoPurge.MinAttempts = ptr(uint32(0))
 	unknown.Transactions.AutoPurge.DetectionApiUrl = new(config.URL)
@@ -166,6 +167,7 @@ func TestDocs(t *testing.T) {
 		docDefaults.Transactions.TransactionManagerV2.ReadRequestsToMultipleNodes = nil
 		docDefaults.Transactions.TransactionManagerV2.Bundles = nil
 		docDefaults.Transactions.TransactionManagerV2.FastlaneAuctionRequestTimeout = nil
+		docDefaults.Transactions.TransactionManagerV2.TransactionPercentile = nil
 
 		// Fallback DA oracle is not set
 		docDefaults.GasEstimator.DAOracle = DAOracle{}
@@ -295,6 +297,7 @@ var fullConfig = EVMConfig{
 				BlockTime:                     config.MustNewDuration(42 * time.Second),
 				CustomURL:                     config.MustParseURL("http://txs.org"),
 				FastlaneAuctionRequestTimeout: config.MustNewDuration(15 * time.Second),
+				TransactionPercentile:         ptr[uint16](70),
 			},
 		},
 

--- a/pkg/config/toml/docs.toml
+++ b/pkg/config/toml/docs.toml
@@ -177,6 +177,12 @@ ReadRequestsToMultipleNodes = false # Example
 Bundles = false # Example
 # FastlaneAuctionRequestTimeout configures the HTTP request timeout for Fastlane Atlas auction requests. Defaults to 5s if not set.
 FastlaneAuctionRequestTimeout = '5s' # Example
+# TransactionPercentile overrides the RewardPercentile used by the TxM v2 FeeHistory estimator.
+# TxM v2 always uses a FeeHistory estimator regardless of the GasEstimator.Mode setting.
+# If not set, falls back to GasEstimator.BlockHistory.TransactionPercentile.
+# Note: this setting has no effect when EIP1559DynamicFees is false, because in legacy mode
+# the FeeHistory estimator uses eth_gasPrice which does not use percentiles.
+TransactionPercentile = 60 # Example
 
 [BalanceMonitor]
 # Enabled balance monitoring for all keys.

--- a/pkg/config/toml/testdata/config-full.toml
+++ b/pkg/config/toml/testdata/config-full.toml
@@ -50,6 +50,7 @@ DualBroadcast = true
 ReadRequestsToMultipleNodes = false
 Bundles = false
 FastlaneAuctionRequestTimeout = '15s'
+TransactionPercentile = 70
 
 [BalanceMonitor]
 Enabled = true


### PR DESCRIPTION
Simple change to enable a separate, utilitarian SVR gas config. This was chosen over a more complex but general solution because it provides the core feature we want - ability to choose more aggressive gas prices for Txmv2, without interface changes or complicating the node config. 

Both the txmv1 and txmv2 have their own gas estimators. Txmv1 uses the current config and it can be whatever mode. Txmv2's estimator has to be FeeEstimator, and reads the general config for values EXCEPT for the TransactionPercentile which it can specify as a different value under the Txmv2 config (else it fallsback to the general config).