### PR TITLE
CCIP-9203 call updated rpc latency metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022073203-7d8ae8cf67c1
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260326122810-b657beadfb57
-	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260310180305-3ee91a6d9ae9
+	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260326154442-19321a900915
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20260401162955-be2bc6b5264b
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260326111235-8c09d1a4491f
 	github.com/smartcontractkit/chainlink-protos/svr v1.1.1-0.20260203131522-bb8bc5c423b3

--- a/go.sum
+++ b/go.sum
@@ -666,8 +666,8 @@ github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-202508181755
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20250818175541-3389ac08a563/go.mod h1:jP5mrOLFEYZZkl7EiCHRRIMSSHCQsYypm1OZSus//iI=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260326122810-b657beadfb57 h1:sCrr1Oy/JZstf/Oi2cRuU4mDN1BRUKfXP2CKByCMADg=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260326122810-b657beadfb57/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
-github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260310180305-3ee91a6d9ae9 h1:GK+2aFpW/Z5ZnMGCa9NU6o7LKHQ/9xJVZx2yMAMudnc=
-github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260310180305-3ee91a6d9ae9/go.mod h1:HG/aei0MgBOpsyRLexdKGtOUO8yjSJO3iUu0Uu8KBm4=
+github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260326154442-19321a900915 h1:AsCWJfE3+SAfxziohbVLibqHC0kpRHza0D4V7tO0xK8=
+github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260326154442-19321a900915/go.mod h1:HG/aei0MgBOpsyRLexdKGtOUO8yjSJO3iUu0Uu8KBm4=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20260401162955-be2bc6b5264b h1:CNfoAw4HzvaeGwFHavdqU09DCGqVBzwe4dUr82qVZMs=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20260401162955-be2bc6b5264b/go.mod h1:n865LsUxibw9oJM0pH74EBiejJ/x/AgIGHaD99D3SDY=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260326111235-8c09d1a4491f h1:8p3vE987AHM3Of1JvnNJXNE/AtWtfNvJhk3TeeAG3Qw=

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -22,7 +22,7 @@ type rpcClientMetrics struct {
 
 func newRPCClientMetrics(chainID *big.Int) (*rpcClientMetrics, error) {
 	baseRPCMetrics, err := metrics.NewRPCClientMetrics(metrics.RPCClientMetricsConfig{
-		ChainFamily: "EVM",
+		ChainFamily: metrics.EVM,
 		ChainID:     chainID.String(),
 	})
 	if err != nil {
@@ -54,7 +54,7 @@ func newRPCClientMetrics(chainID *big.Int) (*rpcClientMetrics, error) {
 
 func (m *rpcClientMetrics) IncrementTotal(ctx context.Context, chainID, nodeName, rpcDomain, callName string) {
 	m.callsTotal.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("chainFamily", "EVM"),
+		attribute.String("chainFamily", metrics.EVM),
 		attribute.String("chainID", chainID),
 		attribute.String("nodeName", nodeName),
 		attribute.String("rpcDomain", rpcDomain),
@@ -64,7 +64,7 @@ func (m *rpcClientMetrics) IncrementTotal(ctx context.Context, chainID, nodeName
 
 func (m *rpcClientMetrics) IncrementSuccess(ctx context.Context, chainID, nodeName, rpcDomain, callName string) {
 	m.callsSuccess.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("chainFamily", "EVM"),
+		attribute.String("chainFamily", metrics.EVM),
 		attribute.String("chainID", chainID),
 		attribute.String("nodeName", nodeName),
 		attribute.String("rpcDomain", rpcDomain),
@@ -74,7 +74,7 @@ func (m *rpcClientMetrics) IncrementSuccess(ctx context.Context, chainID, nodeNa
 
 func (m *rpcClientMetrics) IncrementFailed(ctx context.Context, chainID, nodeName, rpcDomain, callName string) {
 	m.callsFailed.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("chainFamily", "EVM"),
+		attribute.String("chainFamily", metrics.EVM),
 		attribute.String("chainID", chainID),
 		attribute.String("nodeName", nodeName),
 		attribute.String("rpcDomain", rpcDomain),

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -3,20 +3,32 @@ package client
 import (
 	"context"
 	"fmt"
+	"math/big"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+	"github.com/smartcontractkit/chainlink-framework/metrics"
 )
 
 type rpcClientMetrics struct {
-	callsTotal   metric.Int64Counter
-	callsSuccess metric.Int64Counter
-	callsFailed  metric.Int64Counter
+	rpcClientMetrics metrics.RPCClientMetrics
+	callsTotal       metric.Int64Counter
+	callsSuccess     metric.Int64Counter
+	callsFailed      metric.Int64Counter
 }
 
-func newRPCClientMetrics() (*rpcClientMetrics, error) {
+func newRPCClientMetrics(chainID *big.Int) (*rpcClientMetrics, error) {
+	baseRPCMetrics, err := metrics.NewRPCClientMetrics(metrics.RPCClientMetricsConfig{
+		ChainFamily: "EVM",
+		ChainID:     chainID.String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize rpc base metrics: %w", err)
+	}
+
 	callsTotal, err := beholder.GetMeter().Int64Counter("evm_pool_rpc_node_calls_total")
 	if err != nil {
 		return nil, fmt.Errorf("failed to register rpc calls total metric: %w", err)
@@ -33,9 +45,10 @@ func newRPCClientMetrics() (*rpcClientMetrics, error) {
 	}
 
 	return &rpcClientMetrics{
-		callsTotal:   callsTotal,
-		callsSuccess: callsSuccess,
-		callsFailed:  callsFailed,
+		rpcClientMetrics: baseRPCMetrics,
+		callsTotal:       callsTotal,
+		callsSuccess:     callsSuccess,
+		callsFailed:      callsFailed,
 	}, nil
 }
 
@@ -67,4 +80,8 @@ func (m *rpcClientMetrics) IncrementFailed(ctx context.Context, chainID, nodeNam
 		attribute.String("rpcDomain", rpcDomain),
 		attribute.String("callName", callName),
 	))
+}
+
+func (m *rpcClientMetrics) RecordLatency(ctx context.Context, rpcDomain, callName string, isSendOnly bool, latency time.Duration, err error) {
+	m.rpcClientMetrics.RecordRequest(ctx, rpcDomain, isSendOnly, callName, latency, err)
 }

--- a/pkg/client/metrics_test.go
+++ b/pkg/client/metrics_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +10,7 @@ import (
 )
 
 func TestNewRPCClientMetrics(t *testing.T) {
-	m, err := newRPCClientMetrics()
+	m, err := newRPCClientMetrics(big.NewInt(1))
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	assert.NotNil(t, m.callsTotal)
@@ -18,7 +19,7 @@ func TestNewRPCClientMetrics(t *testing.T) {
 }
 
 func TestRPCClientMetrics_Increment(t *testing.T) {
-	m, err := newRPCClientMetrics()
+	m, err := newRPCClientMetrics(big.NewInt(1))
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/pkg/client/metrics_test.go
+++ b/pkg/client/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,7 @@ func TestNewRPCClientMetrics(t *testing.T) {
 	m, err := newRPCClientMetrics(big.NewInt(1))
 	require.NoError(t, err)
 	require.NotNil(t, m)
+	assert.NotNil(t, m.rpcClientMetrics)
 	assert.NotNil(t, m.callsTotal)
 	assert.NotNil(t, m.callsSuccess)
 	assert.NotNil(t, m.callsFailed)
@@ -24,6 +26,9 @@ func TestRPCClientMetrics_Increment(t *testing.T) {
 
 	ctx := context.Background()
 
+	assert.NotPanics(t, func() {
+		m.RecordLatency(ctx, "rpc.example.com","eth_call", false, time.Second, nil)
+	})
 	assert.NotPanics(t, func() {
 		m.IncrementTotal(ctx, "1", "node-1", "rpc.example.com", "eth_call")
 	})

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -29,7 +29,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
-	"github.com/smartcontractkit/chainlink-framework/metrics"
 	"github.com/smartcontractkit/chainlink-framework/multinode"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
@@ -172,7 +171,7 @@ func NewRPCClient(
 	)
 	r.rpcLog = logger.Sugared(lggr).Named("RPC")
 
-	bm, bmErr := newRPCClientMetrics()
+	bm, bmErr := newRPCClientMetrics(chainID)
 	if bmErr != nil {
 		lggr.Warnw("Failed to initialize beholder metrics for RPC client", "err", bmErr)
 	} else {
@@ -357,18 +356,8 @@ func (r *RPCClient) logResult(
 		} else {
 			r.beholderMetrics.IncrementFailed(ctx, chainID, r.name, rpcDomain, callName)
 		}
+		r.beholderMetrics.RecordLatency(ctx, rpcDomain, callName, false, callDuration, err)
 	}
-
-	metrics.RPCCallLatency.
-		WithLabelValues(
-			metrics.EVM,                    // chain family
-			r.chainID.String(),             // chain id
-			rpcDomain,                      // rpc url
-			"false",                        // is send only
-			strconv.FormatBool(err == nil), // is successful
-			callName,                       // rpc call name
-		).
-		Observe(float64(callDuration))
 
 	// TODO: Remove deprecated metric
 	promEVMPoolRPCCallTiming.


### PR DESCRIPTION
Bumps `github.com/smartcontractkit/chainlink-framework/metrics` to commit https://github.com/smartcontractkit/chainlink-framework/commit/19321a900915eb7124f7f99cd21d9a17dea99546 and record rpc latency inside `rpcClientMetrics` struct