### PR TITLE
pkg/mercury: fix a race on failed startup

### DIFF
--- a/pkg/mercury/transmitter.go
+++ b/pkg/mercury/transmitter.go
@@ -330,7 +330,7 @@ func NewTransmitter(lggr logger.Logger, cfg TransmitterConfig, clients map[strin
 	}
 }
 
-func (mt *mercuryTransmitter) Start(ctx context.Context) (err error) {
+func (mt *mercuryTransmitter) Start(ctx context.Context) error {
 	return mt.StartOnce("MercuryTransmitter", func() error {
 		mt.lggr.Debugw("Loading transmit requests from database")
 
@@ -350,12 +350,18 @@ func (mt *mercuryTransmitter) Start(ctx context.Context) (err error) {
 				go s.runQueueLoop(mt.stopCh, mt.wg, mt.feedID.Hex())
 			}
 			if err := (&services.MultiStart{}).Start(ctx, startClosers...); err != nil {
+				mt.stopAndWait() // halt spawned goroutines
 				return err
 			}
 		}
 
 		return nil
 	})
+}
+
+func (mt *mercuryTransmitter) stopAndWait() {
+	close(mt.stopCh)
+	mt.wg.Wait()
 }
 
 func (mt *mercuryTransmitter) Close() error {
@@ -369,8 +375,7 @@ func (mt *mercuryTransmitter) Close() error {
 			return err
 		}
 
-		close(mt.stopCh)
-		mt.wg.Wait()
+		mt.stopAndWait()
 
 		// Close all the persistence managers
 		// Close all the clients


### PR DESCRIPTION
When startup partially fails, spawned background goroutines were leaked.
```
==================
WARNING: DATA RACE
Read at 0x00c02f2c4698 by goroutine 199715:
  github.com/smartcontractkit/chainlink-data-streams/mercury/wsrpc.(*client).waitForReady.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-data-streams@v0.1.13/mercury/wsrpc/client.go:276 +0x4c
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).IfStarted()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/state.go:164 +0x90
  github.com/smartcontractkit/chainlink-data-streams/mercury/wsrpc.(*client).waitForReady()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-data-streams@v0.1.13/mercury/wsrpc/client.go:275 +0x94
  github.com/smartcontractkit/chainlink-data-streams/mercury/wsrpc.(*client).Transmit.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-data-streams@v0.1.13/mercury/wsrpc/client.go:291 +0xe0
  github.com/smartcontractkit/chainlink-common/pkg/services.(*StateMachine).IfStarted()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/services/state.go:164 +0x90
  github.com/smartcontractkit/chainlink-data-streams/mercury/wsrpc.(*client).Transmit()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-data-streams@v0.1.13/mercury/wsrpc/client.go:288 +0xc4
  github.com/smartcontractkit/chainlink-data-streams/mercury/wsrpc.(*connection).Transmit()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-data-streams@v0.1.13/mercury/wsrpc/pool.go:81 +0x144
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:238 +0xc4
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:238 +0xc4
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*server).runQueueLoop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:239 +0x114
  github.com/smartcontractkit/chainlink-evm/pkg/mercury.(*mercuryTransmitter).Start.func1.gowrap2()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-evm@v0.3.4-0.20260330133421-5151ea0c3b05/pkg/mercury/transmitter.go:350 +0x54

Previous write at 0x00c02f2c4698 by goroutine 199680:
  github.com/smartcontractkit/chainlink-data-streams/mercury/wsrpc.(*client).dial()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-data-streams@v0.1.13/mercury/wsrpc/client.go:193 +0x3d8
  github.com/smartcontractkit/chainlink-data-streams/mercury/wsrpc.(*client).resetTransport()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-data-streams@v0.1.13/mercury/wsrpc/client.go:229 +0x1e0
  github.com/smartcontractkit/chainlink-data-streams/mercury/wsrpc.(*client).runloop()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-data-streams@v0.1.13/mercury/wsrpc/client.go:208 +0x88
  github.com/smartcontractkit/chainlink-data-streams/mercury/wsrpc.(*client).Start.func1.gowrap1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-data-streams@v0.1.13/mercury/wsrpc/client.go:166 +0x2c

Goroutine 199715 (running) created at:
  github.com/jmoiron/sqlx.SelectContext()
      /Users/jordan/go/pkg/mod/github.com/jmoiron/sqlx@v1.4.0/sqlx_context.go:62 +0xf0
  github.com/jmoiron/sqlx.(*DB).SelectContext()
      /Users/jordan/go/pkg/mod/github.com/jmoiron/sqlx@v1.4.0/sqlx_context.go:141 +0x78
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.(*wrappedDataSource).SelectContext.func1()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/sqlutil/hook.go:154 +0x9c
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.NewApplicationWithConfig.TimeoutHook.func3()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/sqlutil/timeout.go:20 +0xac
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.(*wrappedDataSource).SelectContext()
      /Users/jordan/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.11.2-0.20260331163339-a3c0d217e843/pkg/sqlutil/hook.go:153 +0x1c4
  github.com/smartcontractkit/chainlink/v2/core/bridges.(*orm).FindBridges()
      /Users/jordan/git/chainlink/core/bridges/orm.go:77 +0x17c
  github.com/smartcontractkit/chainlink/v2/core/services/job.(*orm).AssertBridgesExist()
      /Users/jordan/git/chainlink/core/services/job/orm.go:161 +0x2f8
  github.com/smartcontractkit/chainlink/v2/core/services/job.(*orm).CreateJob()
      /Users/jordan/git/chainlink/core/services/job/orm.go:178 +0x2ac
  github.com/smartcontractkit/chainlink/v2/core/services/job.(*spawner).CreateJob()
      /Users/jordan/git/chainlink/core/services/job/spawner.go:264 +0x100
  github.com/smartcontractkit/chainlink/v2/core/services/chainlink.(*ChainlinkApplication).AddJobV2()
      /Users/jordan/git/chainlink/core/services/chainlink/application.go:1059 +0x7c
  github.com/smartcontractkit/chainlink/v2/core/internal/cltest.(*TestApplication).AddJobV2()
      <autogenerated>:1 +0x18
```