### PR TITLE
PLEX-2810

### DIFF
--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -733,6 +734,20 @@ const (
 
 	jsonRPCQuicknodeTooManyResults = -32614 // Undocumented error code used by Quicknode for too many results error
 )
+
+// batchRPCResponseEnvelopeUnmarshal is the substring returned by go-ethereum's rpc
+// client when the HTTP body is a single JSON-RPC object (typically an error envelope)
+// instead of an array of responses. Providers often do this when batch limits are exceeded.
+const batchRPCResponseEnvelopeUnmarshal = "cannot unmarshal object into Go value of type []*rpc.jsonrpcMessage"
+
+func IsBatchRPCResponseEnvelopeUnmarshalError(err error) bool {
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		if strings.Contains(cur.Error(), batchRPCResponseEnvelopeUnmarshal) {
+			return true
+		}
+	}
+	return false
+}
 
 func IsTooManyResults(err error, clientErrors config.ClientErrors) bool {
 	// Context timeouts often occur when receiving too many results from RPCs

--- a/pkg/client/errors_test.go
+++ b/pkg/client/errors_test.go
@@ -580,6 +580,15 @@ func Test_IsTooManyResultsError(t *testing.T) {
 	})
 }
 
+func Test_IsBatchRPCResponseEnvelopeUnmarshalError(t *testing.T) {
+	t.Parallel()
+	inner := errors.New(`json: cannot unmarshal object into Go value of type []*rpc.jsonrpcMessage`)
+	assert.True(t, evmclient.IsBatchRPCResponseEnvelopeUnmarshalError(inner))
+	assert.True(t, evmclient.IsBatchRPCResponseEnvelopeUnmarshalError(fmt.Errorf("wrapped: %w", inner)))
+	assert.False(t, evmclient.IsBatchRPCResponseEnvelopeUnmarshalError(nil))
+	assert.False(t, evmclient.IsBatchRPCResponseEnvelopeUnmarshalError(errors.New("RPC call failed: some other failure")))
+}
+
 func Test_IsMissingBlocksError(t *testing.T) {
 	customErrors := evmclient.NewTestClientErrors()
 

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -418,11 +418,12 @@ func (r *RPCClient) BatchCallContext(rootCtx context.Context, b []rpc.BatchElem)
 
 	ctx, cancel, client := r.makeLiveQueryCtxAndSafeGetClient(rootCtx, r.largePayloadRPCTimeout)
 	defer cancel()
-	lggr := r.newRqLggr().With("nBatchElems", len(b))
 
 	logElems := batchElemsForLog(b)
 
-	lggr.Tracew("RPC call: evmclient.Client#BatchCallContext", "batchElems", logElems)
+	lggr := r.newRqLggr().With("nBatchElems", len(b), "batchElems", logElems)
+
+	lggr.Tracew("RPC call: evmclient.Client#BatchCallContext")
 	start := time.Now()
 	err := r.wrapRPCClientError(client.rpc.BatchCallContext(ctx, b))
 	duration := time.Since(start)

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -369,6 +369,28 @@ func (r *RPCClient) CallContext(ctx context.Context, result interface{}, method 
 	return err
 }
 
+// batchElemLog is a logging-safe view of rpc.BatchElem that omits Result. After
+// BatchCallContext returns, Result fields may hold large payloads (for example
+// many eth_getTransactionReceipt responses); including them in logger context
+// massively increases log volume even when the batch fails.
+type batchElemLog struct {
+	Method string
+	Args   []interface{}
+	Error  error
+}
+
+func batchElemsForLog(b []rpc.BatchElem) []batchElemLog {
+	out := make([]batchElemLog, len(b))
+	for i := range b {
+		out[i] = batchElemLog{
+			Method: b[i].Method,
+			Args:   b[i].Args,
+			Error:  b[i].Error,
+		}
+	}
+	return out
+}
+
 func (r *RPCClient) BatchCallContext(rootCtx context.Context, b []rpc.BatchElem) error {
 	// Astar's finality tags provide weaker finality guarantees than we require.
 	// Fetch latest finalized block using Astar's custom requests and populate it after batch request completes
@@ -396,14 +418,16 @@ func (r *RPCClient) BatchCallContext(rootCtx context.Context, b []rpc.BatchElem)
 
 	ctx, cancel, client := r.makeLiveQueryCtxAndSafeGetClient(rootCtx, r.largePayloadRPCTimeout)
 	defer cancel()
-	lggr := r.newRqLggr().With("nBatchElems", len(b), "batchElems", b)
+	lggr := r.newRqLggr().With("nBatchElems", len(b))
 
-	lggr.Trace("RPC call: evmclient.Client#BatchCallContext")
+	logElems := batchElemsForLog(b)
+
+	lggr.Tracew("RPC call: evmclient.Client#BatchCallContext", "batchElems", logElems)
 	start := time.Now()
 	err := r.wrapRPCClientError(client.rpc.BatchCallContext(ctx, b))
 	duration := time.Since(start)
 
-	r.logResult(ctx, lggr, err, duration, r.getRPCDomain(), "BatchCallContext")
+	r.logResult(ctx, lggr.With("batchElems", logElems), err, duration, r.getRPCDomain(), "BatchCallContext")
 	if err != nil {
 		return err
 	}

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -423,12 +423,12 @@ func (r *RPCClient) BatchCallContext(rootCtx context.Context, b []rpc.BatchElem)
 
 	lggr := r.newRqLggr().With("nBatchElems", len(b), "batchElems", logElems)
 
-	lggr.Tracew("RPC call: evmclient.Client#BatchCallContext")
+	lggr.Trace("RPC call: evmclient.Client#BatchCallContext")
 	start := time.Now()
 	err := r.wrapRPCClientError(client.rpc.BatchCallContext(ctx, b))
 	duration := time.Since(start)
 
-	r.logResult(ctx, lggr.With("batchElems", logElems), err, duration, r.getRPCDomain(), "BatchCallContext")
+	r.logResult(ctx, lggr, err, duration, r.getRPCDomain(), "BatchCallContext")
 	if err != nil {
 		return err
 	}

--- a/pkg/config/toml/config.go
+++ b/pkg/config/toml/config.go
@@ -446,6 +446,10 @@ func (c *Chain) ValidateConfig() (err error) {
 		err = multierr.Append(err, commonconfig.ErrInvalid{Name: "MinIncomingConfirmations", Value: *c.MinIncomingConfirmations,
 			Msg: "must be greater than or equal to 1"})
 	}
+	if *c.RPCDefaultBatchSize < 1 {
+		err = multierr.Append(err, commonconfig.ErrInvalid{Name: "RPCDefaultBatchSize", Value: *c.RPCDefaultBatchSize,
+			Msg: "must be greater than or equal to 1"})
+	}
 
 	if *c.FinalizedBlockOffset > *c.HeadTracker.HistoryDepth {
 		err = multierr.Append(err, commonconfig.ErrInvalid{Name: "HeadTracker.HistoryDepth", Value: *c.HeadTracker.HistoryDepth,

--- a/pkg/config/toml/config_test.go
+++ b/pkg/config/toml/config_test.go
@@ -48,6 +48,24 @@ func TestEVMConfig_ValidateConfig(t *testing.T) {
 	}
 }
 
+func TestEVMConfig_ValidateConfig_RPCDefaultBatchSize(t *testing.T) {
+	name := "fake"
+	id := DefaultIDs[0]
+	evmCfg := &EVMConfig{
+		ChainID: id,
+		Chain:   Defaults(id),
+		Nodes: EVMNodes{{
+			Name:    &name,
+			WSURL:   config.MustParseURL("wss://foo.test/ws"),
+			HTTPURL: config.MustParseURL("http://foo.test"),
+		}},
+	}
+	evmCfg.RPCDefaultBatchSize = ptr[uint32](0)
+	err := config.Validate(evmCfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RPCDefaultBatchSize")
+}
+
 func TestDefaults_fieldsNotNil(t *testing.T) {
 	unknown := Defaults(nil)
 

--- a/pkg/txmgr/evm_tx_store.go
+++ b/pkg/txmgr/evm_tx_store.go
@@ -50,7 +50,7 @@ type EvmTxStore interface {
 	FindTxesByIDs(ctx context.Context, etxIDs []int64, chainID *big.Int) (etxs []*Tx, err error)
 	SaveFetchedReceipts(ctx context.Context, r []*types.Receipt) (err error)
 	UpdateTxStatesToFinalizedUsingTxHashes(ctx context.Context, txHashes []common.Hash, chainID *big.Int) error
-	CountNonTerminalTransactions(ctx context.Context, chainID *big.Int) (count uint32, err error)
+	OldestNonTerminalTxAgeSeconds(ctx context.Context, chainID *big.Int) (seconds float64, err error)
 }
 
 // TxStoreWebApi encapsulates the methods that are not used by the txmgr and only used by the various web controllers, readers, or evm specific components
@@ -1636,18 +1636,23 @@ func (o *evmTxStore) CountTransactionsByState(ctx context.Context, state txmgrty
 	return count, nil
 }
 
-// CountNonTerminalTransactions returns the number of transactions for the chain that are not in a
-// terminal state (finalized or fatal_error). Used for observability of backlog and stuck workflows.
-func (o *evmTxStore) CountNonTerminalTransactions(ctx context.Context, chainID *big.Int) (count uint32, err error) {
+// OldestNonTerminalTxAgeSeconds returns the age in seconds of the oldest evm.tx row that is not in a
+// terminal state (finalized or fatal_error). Returns 0 when there are no such rows. One aggregate
+// over the same filter as a count query—suitable for “stuck tx” style alerts without implying
+// that any non-zero backlog is unhealthy.
+func (o *evmTxStore) OldestNonTerminalTxAgeSeconds(ctx context.Context, chainID *big.Int) (seconds float64, err error) {
 	var cancel context.CancelFunc
 	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
-	err = o.q.GetContext(ctx, &count, `SELECT count(*) FROM evm.txes WHERE evm_chain_id = $1 AND state NOT IN ('finalized', 'fatal_error')`,
+	err = o.q.GetContext(ctx, &seconds, `
+SELECT GREATEST(0::float8, COALESCE(EXTRACT(EPOCH FROM (NOW() - MIN(created_at))), 0::float8))
+FROM evm.txes
+WHERE evm_chain_id = $1 AND state NOT IN ('finalized', 'fatal_error')`,
 		chainID.String())
 	if err != nil {
-		return 0, fmt.Errorf("failed to CountNonTerminalTransactions: %w", err)
+		return 0, fmt.Errorf("failed to OldestNonTerminalTxAgeSeconds: %w", err)
 	}
-	return count, nil
+	return seconds, nil
 }
 
 // CountUnstartedTransactions returns the number of unconfirmed transactions

--- a/pkg/txmgr/evm_tx_store.go
+++ b/pkg/txmgr/evm_tx_store.go
@@ -50,6 +50,7 @@ type EvmTxStore interface {
 	FindTxesByIDs(ctx context.Context, etxIDs []int64, chainID *big.Int) (etxs []*Tx, err error)
 	SaveFetchedReceipts(ctx context.Context, r []*types.Receipt) (err error)
 	UpdateTxStatesToFinalizedUsingTxHashes(ctx context.Context, txHashes []common.Hash, chainID *big.Int) error
+	CountNonTerminalTransactions(ctx context.Context, chainID *big.Int) (count uint32, err error)
 }
 
 // TxStoreWebApi encapsulates the methods that are not used by the txmgr and only used by the various web controllers, readers, or evm specific components
@@ -1631,6 +1632,20 @@ func (o *evmTxStore) CountTransactionsByState(ctx context.Context, state txmgrty
 		state, chainID.String())
 	if err != nil {
 		return 0, fmt.Errorf("failed to CountTransactionsByState: %w", err)
+	}
+	return count, nil
+}
+
+// CountNonTerminalTransactions returns the number of transactions for the chain that are not in a
+// terminal state (finalized or fatal_error). Used for observability of backlog and stuck workflows.
+func (o *evmTxStore) CountNonTerminalTransactions(ctx context.Context, chainID *big.Int) (count uint32, err error) {
+	var cancel context.CancelFunc
+	ctx, cancel = o.stopCh.Ctx(ctx)
+	defer cancel()
+	err = o.q.GetContext(ctx, &count, `SELECT count(*) FROM evm.txes WHERE evm_chain_id = $1 AND state NOT IN ('finalized', 'fatal_error')`,
+		chainID.String())
+	if err != nil {
+		return 0, fmt.Errorf("failed to CountNonTerminalTransactions: %w", err)
 	}
 	return count, nil
 }

--- a/pkg/txmgr/evm_tx_store_test.go
+++ b/pkg/txmgr/evm_tx_store_test.go
@@ -1515,24 +1515,34 @@ func TestORM_CountTransactionsByState(t *testing.T) {
 	assert.Equal(t, int(count), 3)
 }
 
-func TestORM_CountNonTerminalTransactions(t *testing.T) {
+func TestORM_OldestNonTerminalTxAgeSeconds(t *testing.T) {
 	t.Parallel()
 
 	db := testutils.NewSqlxDB(t)
 	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
-	count, err := txStore.CountNonTerminalTransactions(t.Context(), testutils.FixtureChainID)
+	age, err := txStore.OldestNonTerminalTxAgeSeconds(t.Context(), testutils.FixtureChainID)
 	require.NoError(t, err)
-	assert.Equal(t, uint32(0), count)
+	assert.InDelta(t, 0.0, age, 0.0001)
 
 	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
 	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
 	mustInsertFatalErrorEthTx(t, txStore, fromAddress)
 
-	count, err = txStore.CountNonTerminalTransactions(t.Context(), testutils.FixtureChainID)
+	age, err = txStore.OldestNonTerminalTxAgeSeconds(t.Context(), testutils.FixtureChainID)
 	require.NoError(t, err)
-	assert.Equal(t, uint32(2), count, "fatal_error and finalized txs must be excluded from non-terminal count")
+	assert.GreaterOrEqual(t, age, 0.0)
+	assert.Less(t, age, 3600.0, "fresh txs should be far below 1h age")
+
+	_, err = db.ExecContext(t.Context(),
+		`UPDATE evm.txes SET created_at = created_at - interval '2 hours' WHERE evm_chain_id = $1 AND state <> 'fatal_error'`,
+		testutils.FixtureChainID.String())
+	require.NoError(t, err)
+
+	age, err = txStore.OldestNonTerminalTxAgeSeconds(t.Context(), testutils.FixtureChainID)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, age, 7000.0, "oldest non-terminal should reflect backdated created_at (~2h in seconds)")
 }
 
 func TestORM_CountUnstartedTransactions(t *testing.T) {

--- a/pkg/txmgr/evm_tx_store_test.go
+++ b/pkg/txmgr/evm_tx_store_test.go
@@ -1522,7 +1522,7 @@ func TestORM_CountNonTerminalTransactions(t *testing.T) {
 	txStore := txmgrtest.NewTestTxStore(t, db)
 	fromAddress := testutils.NewAddress()
 
-	count, err := txStore.CountNonTerminalTransactions(tests.Context(t), testutils.FixtureChainID)
+	count, err := txStore.CountNonTerminalTransactions(t.Context(), testutils.FixtureChainID)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(0), count)
 
@@ -1530,7 +1530,7 @@ func TestORM_CountNonTerminalTransactions(t *testing.T) {
 	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
 	mustInsertFatalErrorEthTx(t, txStore, fromAddress)
 
-	count, err = txStore.CountNonTerminalTransactions(tests.Context(t), testutils.FixtureChainID)
+	count, err = txStore.CountNonTerminalTransactions(t.Context(), testutils.FixtureChainID)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(2), count, "fatal_error and finalized txs must be excluded from non-terminal count")
 }

--- a/pkg/txmgr/evm_tx_store_test.go
+++ b/pkg/txmgr/evm_tx_store_test.go
@@ -1515,6 +1515,26 @@ func TestORM_CountTransactionsByState(t *testing.T) {
 	assert.Equal(t, int(count), 3)
 }
 
+func TestORM_CountNonTerminalTransactions(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.NewSqlxDB(t)
+	txStore := txmgrtest.NewTestTxStore(t, db)
+	fromAddress := testutils.NewAddress()
+
+	count, err := txStore.CountNonTerminalTransactions(tests.Context(t), testutils.FixtureChainID)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0), count)
+
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
+	txmgrtest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, fromAddress)
+	mustInsertFatalErrorEthTx(t, txStore, fromAddress)
+
+	count, err = txStore.CountNonTerminalTransactions(tests.Context(t), testutils.FixtureChainID)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), count, "fatal_error and finalized txs must be excluded from non-terminal count")
+}
+
 func TestORM_CountUnstartedTransactions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/txmgr/finalizer.go
+++ b/pkg/txmgr/finalizer.go
@@ -35,9 +35,8 @@ var (
 
 // processHeadTimeout represents a sanity limit on how long ProcessHead should take to complete
 const (
-	processHeadTimeout                = 10 * time.Minute
-	attemptsCacheRefreshThreshold     = 5
-	receiptBatchRPCEnvelopeRetryDelay = 250 * time.Millisecond
+	processHeadTimeout            = 10 * time.Minute
+	attemptsCacheRefreshThreshold = 5
 )
 
 type finalizerTxStore interface {
@@ -385,20 +384,6 @@ func (f *evmFinalizer) batchCheckReceiptHashesOnchain(ctx context.Context, block
 	return finalizedReceipts
 }
 
-func sleepCtx(ctx context.Context, d time.Duration) error {
-	if d <= 0 {
-		return nil
-	}
-	t := time.NewTimer(d)
-	defer t.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-t.C:
-		return nil
-	}
-}
-
 func (f *evmFinalizer) FetchAndStoreReceipts(ctx context.Context, head, latestFinalizedHead *types.Head) error {
 	attempts, err := f.fetchAttemptsRequiringReceiptFetch(ctx)
 	if err != nil {
@@ -423,17 +408,10 @@ func (f *evmFinalizer) FetchAndStoreReceipts(ctx context.Context, head, latestFi
 				if evmclient.IsBatchRPCResponseEnvelopeUnmarshalError(fetchErr) {
 					chunkLen := len(chunk)
 					if chunkLen <= 1 {
-						f.lggr.Criticalw("Receipt batch fetch failed with batch response envelope error at batch size 1; RPC may be misconfigured or overloaded",
-							"err", fetchErr, "txHash", chunk[0].Hash)
-						errorList = append(errorList, fetchErr)
-						i++
-						break
+						return fmt.Errorf("receipt batch fetch failed with batch response envelope error at batch size 1 (RPC may be misconfigured or overloaded): %w", fetchErr)
 					}
 					chunkSize = max(1, chunkSize/2)
-					if sleepErr := sleepCtx(ctx, receiptBatchRPCEnvelopeRetryDelay); sleepErr != nil {
-						return sleepErr
-					}
-					f.lggr.Warnw("RPC returned a batch response envelope instead of a result array; reducing receipt fetch chunk size for this batch and retrying after delay. If this issue persists, consider adjusting RPCDefaultBatchSize in the node config",
+					f.lggr.Warnw("RPC returned a batch response envelope instead of a result array; reducing receipt fetch chunk size for this batch and retrying. If this issue persists, consider adjusting RPCDefaultBatchSize in the node config",
 						"newChunkSize", chunkSize, "err", fetchErr)
 					continue
 				}

--- a/pkg/txmgr/finalizer.go
+++ b/pkg/txmgr/finalizer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -19,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mailbox"
 
+	evmclient "github.com/smartcontractkit/chainlink-evm/pkg/client"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
@@ -34,8 +36,9 @@ var (
 
 // processHeadTimeout represents a sanity limit on how long ProcessHead should take to complete
 const (
-	processHeadTimeout            = 10 * time.Minute
-	attemptsCacheRefreshThreshold = 5
+	processHeadTimeout                 = 10 * time.Minute
+	attemptsCacheRefreshThreshold      = 5
+	receiptBatchRPCEnvelopeRetryDelay = 250 * time.Millisecond
 )
 
 type finalizerTxStore interface {
@@ -49,6 +52,7 @@ type finalizerTxStore interface {
 	UpdateTxCallbackCompleted(ctx context.Context, pipelineTaskRunID uuid.UUID, chainID *big.Int) error
 	UpdateTxFatalErrorAndDeleteAttempts(ctx context.Context, etx *Tx) error
 	UpdateTxStatesToFinalizedUsingTxHashes(ctx context.Context, txHashes []common.Hash, chainID *big.Int) error
+	CountNonTerminalTransactions(ctx context.Context, chainID *big.Int) (count uint32, err error)
 }
 
 type finalizerChainClient interface {
@@ -66,7 +70,8 @@ type finalizerMetrics interface {
 	IncrementNumRevertedTxs(ctx context.Context)
 	IncrementFwdTxCount(ctx context.Context, successful bool)
 	RecordTxAttemptCount(ctx context.Context, value float64)
-	IncrementNumFinalizedTxs(ctx context.Context)
+	AddNumFinalizedTxs(ctx context.Context, n int64)
+	RecordNonTerminalTxCount(ctx context.Context, count float64)
 }
 
 type resumeCallback = func(context.Context, uuid.UUID, interface{}, error) error
@@ -93,6 +98,8 @@ type evmFinalizer struct {
 
 	attemptsCache         []TxAttempt
 	attemptsCacheHitCount int
+
+	receiptEffectiveBatchSize atomic.Int32
 }
 
 func NewEvmFinalizer(
@@ -204,7 +211,18 @@ func (f *evmFinalizer) ProcessHead(ctx context.Context, head *types.Head) error 
 	if err != nil {
 		f.lggr.Errorf("failed to resume pending task runs: %s", err.Error())
 	}
-	return f.processFinalizedHead(ctx, latestFinalizedHead)
+	err = f.processFinalizedHead(ctx, latestFinalizedHead)
+	f.observeNonTerminalTxCount(ctx)
+	return err
+}
+
+func (f *evmFinalizer) observeNonTerminalTxCount(ctx context.Context) {
+	count, err := f.txStore.CountNonTerminalTransactions(ctx, f.chainID)
+	if err != nil {
+		f.lggr.Errorw("Failed to count non-terminal transactions for metrics", "err", err)
+		return
+	}
+	f.metrics.RecordNonTerminalTxCount(ctx, float64(count))
 }
 
 // processFinalizedHead determines if any confirmed transactions can be marked as finalized by comparing their receipts against the latest finalized block
@@ -294,8 +312,9 @@ func (f *evmFinalizer) processFinalizedHead(ctx context.Context, latestFinalized
 	// Does not need to be protected with mutex lock because the Finalizer only runs in a single loop
 	f.lastProcessedFinalizedBlockNum = latestFinalizedHead.BlockNumber()
 
-	// add newly finalized transactions to the prom metric
-	f.metrics.IncrementNumFinalizedTxs(ctx)
+	if n := int64(len(txHashes)); n > 0 {
+		f.metrics.AddNumFinalizedTxs(ctx, n)
+	}
 
 	return nil
 }
@@ -369,6 +388,56 @@ func (f *evmFinalizer) batchCheckReceiptHashesOnchain(ctx context.Context, block
 	return finalizedReceipts
 }
 
+// receiptOuterBatchCap returns the max number of receipt RPCs to bundle for the given number of
+// attempts remaining, respecting rpcBatchSize config and any lowered effective size.
+func (f *evmFinalizer) receiptOuterBatchCap(remaining int) int {
+	if remaining < 1 {
+		return 1
+	}
+	v := int(f.receiptEffectiveBatchSize.Load())
+	if v > 0 {
+		if f.rpcBatchSize > 0 {
+			return min(v, f.rpcBatchSize, remaining)
+		}
+		return min(v, remaining)
+	}
+	if f.rpcBatchSize == 0 {
+		return remaining
+	}
+	return min(f.rpcBatchSize, remaining)
+}
+
+func (f *evmFinalizer) setReceiptEffectiveBatchSize(n int) {
+	if n < 1 {
+		n = 1
+	}
+	if f.rpcBatchSize > 0 && n > f.rpcBatchSize {
+		n = f.rpcBatchSize
+	}
+	prev := int(f.receiptEffectiveBatchSize.Load())
+	if prev == 0 || n < prev {
+		f.receiptEffectiveBatchSize.Store(int32(n))
+	}
+}
+
+func (f *evmFinalizer) resetReceiptEffectiveBatchSize() {
+	f.receiptEffectiveBatchSize.Store(0)
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
 func (f *evmFinalizer) FetchAndStoreReceipts(ctx context.Context, head, latestFinalizedHead *types.Head) error {
 	attempts, err := f.fetchAttemptsRequiringReceiptFetch(ctx)
 	if err != nil {
@@ -381,37 +450,74 @@ func (f *evmFinalizer) FetchAndStoreReceipts(ctx context.Context, head, latestFi
 
 	f.lggr.Debugw(fmt.Sprintf("Fetching receipts for %v transaction attempts", len(attempts)))
 
-	batchSize := f.rpcBatchSize
-	if batchSize == 0 {
-		batchSize = len(attempts)
-	}
 	allReceipts := make([]*types.Receipt, 0, len(attempts))
 	errorList := make([]error, 0, len(attempts))
-	for i := 0; i < len(attempts); i += batchSize {
-		j := i + batchSize
+	for i := 0; i < len(attempts); {
+		remaining := len(attempts) - i
+		outerCap := f.receiptOuterBatchCap(remaining)
+		j := i + outerCap
 		if j > len(attempts) {
 			j = len(attempts)
 		}
 		batch := attempts[i:j]
 
-		receipts, fetchErr := f.batchFetchReceipts(ctx, batch)
-		if fetchErr != nil {
-			errorList = append(errorList, fetchErr)
-			continue
+		offset := 0
+		subBatch := outerCap
+		if subBatch < 1 {
+			subBatch = 1
 		}
+		for offset < len(batch) {
+			chunkEnd := offset + subBatch
+			if chunkEnd > len(batch) {
+				chunkEnd = len(batch)
+			}
+			chunk := batch[offset:chunkEnd]
 
-		allReceipts = append(allReceipts, receipts...)
+			receipts, fetchErr := f.batchFetchReceipts(ctx, chunk)
+			if fetchErr != nil {
+				if evmclient.IsBatchRPCResponseEnvelopeUnmarshalError(fetchErr) {
+					chunkLen := len(chunk)
+					if chunkLen <= 1 {
+						f.lggr.Criticalw("Receipt batch fetch failed with batch response envelope error at batch size 1; RPC may be misconfigured or overloaded",
+							"err", fetchErr, "txHash", chunk[0].Hash)
+						errorList = append(errorList, fetchErr)
+						offset = chunkEnd
+						continue
+					}
+					subBatch = max(1, subBatch/2)
+					f.setReceiptEffectiveBatchSize(subBatch)
+					if err := sleepCtx(ctx, receiptBatchRPCEnvelopeRetryDelay); err != nil {
+						return err
+					}
+					f.lggr.Warnw("RPC returned a batch response envelope instead of a result array; reducing receipt fetch batch size and retrying after delay",
+						"newSubBatch", subBatch, "err", fetchErr)
+					continue
+				}
+				errorList = append(errorList, fetchErr)
+				offset = chunkEnd
+				continue
+			}
 
-		if err = f.txStore.SaveFetchedReceipts(ctx, receipts); err != nil {
-			errorList = append(errorList, err)
-			continue
+			allReceipts = append(allReceipts, receipts...)
+
+			if err = f.txStore.SaveFetchedReceipts(ctx, receipts); err != nil {
+				errorList = append(errorList, err)
+				offset = chunkEnd
+				continue
+			}
+			f.filterAttemptsCache(receipts)
+			offset = chunkEnd
+			subBatch = f.receiptOuterBatchCap(len(batch) - offset)
+			if subBatch < 1 {
+				subBatch = 1
+			}
 		}
-		// Filter out attempts with found receipts from cache, if needed
-		f.filterAttemptsCache(receipts)
+		i = j
 	}
 	if len(errorList) > 0 {
 		return errors.Join(errorList...)
 	}
+	f.resetReceiptEffectiveBatchSize()
 
 	oldTxIDs := findOldTxIDsWithoutReceipts(attempts, allReceipts, latestFinalizedHead)
 	// Process old transactions that never received receipts and need to be marked as fatal

--- a/pkg/txmgr/finalizer.go
+++ b/pkg/txmgr/finalizer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -52,7 +51,7 @@ type finalizerTxStore interface {
 	UpdateTxCallbackCompleted(ctx context.Context, pipelineTaskRunID uuid.UUID, chainID *big.Int) error
 	UpdateTxFatalErrorAndDeleteAttempts(ctx context.Context, etx *Tx) error
 	UpdateTxStatesToFinalizedUsingTxHashes(ctx context.Context, txHashes []common.Hash, chainID *big.Int) error
-	CountNonTerminalTransactions(ctx context.Context, chainID *big.Int) (count uint32, err error)
+	OldestNonTerminalTxAgeSeconds(ctx context.Context, chainID *big.Int) (seconds float64, err error)
 }
 
 type finalizerChainClient interface {
@@ -71,7 +70,7 @@ type finalizerMetrics interface {
 	IncrementFwdTxCount(ctx context.Context, successful bool)
 	RecordTxAttemptCount(ctx context.Context, value float64)
 	AddNumFinalizedTxs(ctx context.Context, n int64)
-	RecordNonTerminalTxCount(ctx context.Context, count float64)
+	RecordOldestNonTerminalTxAgeSeconds(ctx context.Context, seconds float64)
 }
 
 type resumeCallback = func(context.Context, uuid.UUID, interface{}, error) error
@@ -98,8 +97,6 @@ type evmFinalizer struct {
 
 	attemptsCache         []TxAttempt
 	attemptsCacheHitCount int
-
-	receiptEffectiveBatchSize atomic.Int64
 }
 
 func NewEvmFinalizer(
@@ -116,7 +113,7 @@ func NewEvmFinalizer(
 	return &evmFinalizer{
 		lggr:                  logger.Sugared(lggr),
 		chainID:               chainID,
-		rpcBatchSize:          int(rpcBatchSize),
+		rpcBatchSize:          int(rpcBatchSize), //nolint:gosec // G115 -- RPC batch size is a small config value
 		forwardersEnabled:     forwardersEnabled,
 		txStore:               txStore,
 		client:                client,
@@ -212,17 +209,17 @@ func (f *evmFinalizer) ProcessHead(ctx context.Context, head *types.Head) error 
 		f.lggr.Errorf("failed to resume pending task runs: %s", err.Error())
 	}
 	err = f.processFinalizedHead(ctx, latestFinalizedHead)
-	f.observeNonTerminalTxCount(ctx)
+	f.observeOldestNonTerminalTxAge(ctx)
 	return err
 }
 
-func (f *evmFinalizer) observeNonTerminalTxCount(ctx context.Context) {
-	count, err := f.txStore.CountNonTerminalTransactions(ctx, f.chainID)
+func (f *evmFinalizer) observeOldestNonTerminalTxAge(ctx context.Context) {
+	age, err := f.txStore.OldestNonTerminalTxAgeSeconds(ctx, f.chainID)
 	if err != nil {
-		f.lggr.Errorw("Failed to count non-terminal transactions for metrics", "err", err)
+		f.lggr.Errorw("Failed to load oldest non-terminal transaction age for metrics", "err", err)
 		return
 	}
-	f.metrics.RecordNonTerminalTxCount(ctx, float64(count))
+	f.metrics.RecordOldestNonTerminalTxAgeSeconds(ctx, age)
 }
 
 // processFinalizedHead determines if any confirmed transactions can be marked as finalized by comparing their receipts against the latest finalized block
@@ -388,42 +385,6 @@ func (f *evmFinalizer) batchCheckReceiptHashesOnchain(ctx context.Context, block
 	return finalizedReceipts
 }
 
-// receiptOuterBatchCap returns the max number of receipt RPCs to bundle for the given number of
-// attempts remaining, respecting rpcBatchSize config and any lowered effective size.
-func (f *evmFinalizer) receiptOuterBatchCap(remaining int) int {
-	if remaining < 1 {
-		return 1
-	}
-	v := int(f.receiptEffectiveBatchSize.Load())
-	if v > 0 {
-		if f.rpcBatchSize > 0 {
-			return min(v, f.rpcBatchSize, remaining)
-		}
-		return min(v, remaining)
-	}
-	if f.rpcBatchSize == 0 {
-		return remaining
-	}
-	return min(f.rpcBatchSize, remaining)
-}
-
-func (f *evmFinalizer) setReceiptEffectiveBatchSize(n int) {
-	if n < 1 {
-		n = 1
-	}
-	if f.rpcBatchSize > 0 && n > f.rpcBatchSize {
-		n = f.rpcBatchSize
-	}
-	prev := f.receiptEffectiveBatchSize.Load()
-	if prev == 0 || int64(n) < prev {
-		f.receiptEffectiveBatchSize.Store(int64(n))
-	}
-}
-
-func (f *evmFinalizer) resetReceiptEffectiveBatchSize() {
-	f.receiptEffectiveBatchSize.Store(0)
-}
-
 func sleepCtx(ctx context.Context, d time.Duration) error {
 	if d <= 0 {
 		return nil
@@ -453,26 +414,10 @@ func (f *evmFinalizer) FetchAndStoreReceipts(ctx context.Context, head, latestFi
 	allReceipts := make([]*types.Receipt, 0, len(attempts))
 	errorList := make([]error, 0, len(attempts))
 	for i := 0; i < len(attempts); {
-		remaining := len(attempts) - i
-		outerCap := f.receiptOuterBatchCap(remaining)
-		j := i + outerCap
-		if j > len(attempts) {
-			j = len(attempts)
-		}
-		batch := attempts[i:j]
-
-		offset := 0
-		subBatch := outerCap
-		if subBatch < 1 {
-			subBatch = 1
-		}
-		for offset < len(batch) {
-			chunkEnd := offset + subBatch
-			if chunkEnd > len(batch) {
-				chunkEnd = len(batch)
-			}
-			chunk := batch[offset:chunkEnd]
-
+		maxChunk := min(f.rpcBatchSize, len(attempts)-i)
+		chunkSize := maxChunk
+		for {
+			chunk := attempts[i : i+chunkSize]
 			receipts, fetchErr := f.batchFetchReceipts(ctx, chunk)
 			if fetchErr != nil {
 				if evmclient.IsBatchRPCResponseEnvelopeUnmarshalError(fetchErr) {
@@ -481,43 +426,37 @@ func (f *evmFinalizer) FetchAndStoreReceipts(ctx context.Context, head, latestFi
 						f.lggr.Criticalw("Receipt batch fetch failed with batch response envelope error at batch size 1; RPC may be misconfigured or overloaded",
 							"err", fetchErr, "txHash", chunk[0].Hash)
 						errorList = append(errorList, fetchErr)
-						offset = chunkEnd
-						continue
+						i++
+						break
 					}
-					subBatch = max(1, subBatch/2)
-					f.setReceiptEffectiveBatchSize(subBatch)
+					chunkSize = max(1, chunkSize/2)
 					if sleepErr := sleepCtx(ctx, receiptBatchRPCEnvelopeRetryDelay); sleepErr != nil {
 						return sleepErr
 					}
-					f.lggr.Warnw("RPC returned a batch response envelope instead of a result array; reducing receipt fetch batch size and retrying after delay",
-						"newSubBatch", subBatch, "err", fetchErr)
+					f.lggr.Warnw("RPC returned a batch response envelope instead of a result array; reducing receipt fetch chunk size for this batch and retrying after delay",
+						"newChunkSize", chunkSize, "err", fetchErr)
 					continue
 				}
 				errorList = append(errorList, fetchErr)
-				offset = chunkEnd
-				continue
+				i += chunkSize
+				break
 			}
 
 			allReceipts = append(allReceipts, receipts...)
 
 			if err = f.txStore.SaveFetchedReceipts(ctx, receipts); err != nil {
 				errorList = append(errorList, err)
-				offset = chunkEnd
-				continue
+				i += chunkSize
+				break
 			}
 			f.filterAttemptsCache(receipts)
-			offset = chunkEnd
-			subBatch = f.receiptOuterBatchCap(len(batch) - offset)
-			if subBatch < 1 {
-				subBatch = 1
-			}
+			i += chunkSize
+			break
 		}
-		i = j
 	}
 	if len(errorList) > 0 {
 		return errors.Join(errorList...)
 	}
-	f.resetReceiptEffectiveBatchSize()
 
 	oldTxIDs := findOldTxIDsWithoutReceipts(attempts, allReceipts, latestFinalizedHead)
 	// Process old transactions that never received receipts and need to be marked as fatal

--- a/pkg/txmgr/finalizer.go
+++ b/pkg/txmgr/finalizer.go
@@ -36,8 +36,8 @@ var (
 
 // processHeadTimeout represents a sanity limit on how long ProcessHead should take to complete
 const (
-	processHeadTimeout                 = 10 * time.Minute
-	attemptsCacheRefreshThreshold      = 5
+	processHeadTimeout                = 10 * time.Minute
+	attemptsCacheRefreshThreshold     = 5
 	receiptBatchRPCEnvelopeRetryDelay = 250 * time.Millisecond
 )
 
@@ -99,7 +99,7 @@ type evmFinalizer struct {
 	attemptsCache         []TxAttempt
 	attemptsCacheHitCount int
 
-	receiptEffectiveBatchSize atomic.Int32
+	receiptEffectiveBatchSize atomic.Int64
 }
 
 func NewEvmFinalizer(
@@ -414,9 +414,9 @@ func (f *evmFinalizer) setReceiptEffectiveBatchSize(n int) {
 	if f.rpcBatchSize > 0 && n > f.rpcBatchSize {
 		n = f.rpcBatchSize
 	}
-	prev := int(f.receiptEffectiveBatchSize.Load())
-	if prev == 0 || n < prev {
-		f.receiptEffectiveBatchSize.Store(int32(n))
+	prev := f.receiptEffectiveBatchSize.Load()
+	if prev == 0 || int64(n) < prev {
+		f.receiptEffectiveBatchSize.Store(int64(n))
 	}
 }
 
@@ -486,8 +486,8 @@ func (f *evmFinalizer) FetchAndStoreReceipts(ctx context.Context, head, latestFi
 					}
 					subBatch = max(1, subBatch/2)
 					f.setReceiptEffectiveBatchSize(subBatch)
-					if err := sleepCtx(ctx, receiptBatchRPCEnvelopeRetryDelay); err != nil {
-						return err
+					if sleepErr := sleepCtx(ctx, receiptBatchRPCEnvelopeRetryDelay); sleepErr != nil {
+						return sleepErr
 					}
 					f.lggr.Warnw("RPC returned a batch response envelope instead of a result array; reducing receipt fetch batch size and retrying after delay",
 						"newSubBatch", subBatch, "err", fetchErr)

--- a/pkg/txmgr/finalizer.go
+++ b/pkg/txmgr/finalizer.go
@@ -433,7 +433,7 @@ func (f *evmFinalizer) FetchAndStoreReceipts(ctx context.Context, head, latestFi
 					if sleepErr := sleepCtx(ctx, receiptBatchRPCEnvelopeRetryDelay); sleepErr != nil {
 						return sleepErr
 					}
-					f.lggr.Warnw("RPC returned a batch response envelope instead of a result array; reducing receipt fetch chunk size for this batch and retrying after delay",
+					f.lggr.Warnw("RPC returned a batch response envelope instead of a result array; reducing receipt fetch chunk size for this batch and retrying after delay. If this issue persists, consider adjusting RPCDefaultBatchSize in the node config",
 						"newChunkSize", chunkSize, "err", fetchErr)
 					continue
 				}

--- a/pkg/txmgr/finalizer_test.go
+++ b/pkg/txmgr/finalizer_test.go
@@ -490,7 +490,7 @@ func TestFinalizer_FetchAndStoreReceipts(t *testing.T) {
 		db := testutils.NewSqlxDB(t)
 		txStore := txmgrtest.NewTestTxStore(t, db)
 		fromAddress := testutils.NewAddress()
-		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, config.EVM().RPCDefaultBatchSize(), false, txStore, txmClient, ht, metrics)
+		finalizer := txmgr.NewEvmFinalizer(logger.Test(t), testutils.FixtureChainID, rpcBatchSize, false, txStore, txmClient, ht, metrics)
 
 		mustInsertFatalErrorEthTx(t, txStore, fromAddress)
 		mustInsertInProgressEthTx(t, txStore, 0, fromAddress)

--- a/pkg/txmgr/metrics.go
+++ b/pkg/txmgr/metrics.go
@@ -39,6 +39,10 @@ var (
 		Name: "txm_pending_tx_queue_utilization",
 		Help: "Queue utilization in [0,1] = depth/capacity.",
 	}, []string{"chainID"})
+	promNonTerminalTxCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tx_manager_transactions_non_terminal",
+		Help: "Current count of transactions not in a terminal state (finalized or fatal_error).",
+	}, []string{"chainID"})
 )
 
 type evmTxmMetrics struct {
@@ -50,6 +54,7 @@ type evmTxmMetrics struct {
 	txAttemptCount            metric.Float64Gauge
 	numFinalizedTxs           metric.Int64Counter
 	pendingTxQueueUtilization metric.Float64Gauge
+	nonTerminalTxCount        metric.Float64Gauge
 }
 
 func NewEVMTxmMetrics(chainID string) (*evmTxmMetrics, error) {
@@ -88,6 +93,11 @@ func NewEVMTxmMetrics(chainID string) (*evmTxmMetrics, error) {
 		return nil, fmt.Errorf("failed to register pending tx queue utilization: %w", err)
 	}
 
+	nonTerminalTxCount, err := beholder.GetMeter().Float64Gauge("tx_manager_transactions_non_terminal")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register non-terminal transaction count metric: %w", err)
+	}
+
 	return &evmTxmMetrics{
 		chainID:                   chainID,
 		GenericTXMMetrics:         genericTXMMetrics,
@@ -97,6 +107,7 @@ func NewEVMTxmMetrics(chainID string) (*evmTxmMetrics, error) {
 		txAttemptCount:            txAttemptCount,
 		numFinalizedTxs:           numFinalizedTxs,
 		pendingTxQueueUtilization: pendingTxQueueUtilization,
+		nonTerminalTxCount:        nonTerminalTxCount,
 	}, nil
 }
 
@@ -125,7 +136,15 @@ func (m *evmTxmMetrics) RecordTxAttemptCount(ctx context.Context, value float64)
 	m.txAttemptCount.Record(ctx, value, metric.WithAttributes(attribute.String("chainID", m.chainID)))
 }
 
-func (m *evmTxmMetrics) IncrementNumFinalizedTxs(ctx context.Context) {
-	promNumFinalizedTxs.WithLabelValues(m.chainID).Add(float64(1))
-	m.numFinalizedTxs.Add(ctx, 1, metric.WithAttributes(attribute.String("chainID", m.chainID)))
+func (m *evmTxmMetrics) AddNumFinalizedTxs(ctx context.Context, n int64) {
+	if n <= 0 {
+		return
+	}
+	promNumFinalizedTxs.WithLabelValues(m.chainID).Add(float64(n))
+	m.numFinalizedTxs.Add(ctx, n, metric.WithAttributes(attribute.String("chainID", m.chainID)))
+}
+
+func (m *evmTxmMetrics) RecordNonTerminalTxCount(ctx context.Context, count float64) {
+	promNonTerminalTxCount.WithLabelValues(m.chainID).Set(count)
+	m.nonTerminalTxCount.Record(ctx, count, metric.WithAttributes(attribute.String("chainID", m.chainID)))
 }

--- a/pkg/txmgr/metrics.go
+++ b/pkg/txmgr/metrics.go
@@ -39,22 +39,22 @@ var (
 		Name: "txm_pending_tx_queue_utilization",
 		Help: "Queue utilization in [0,1] = depth/capacity.",
 	}, []string{"chainID"})
-	promNonTerminalTxCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "tx_manager_transactions_non_terminal",
-		Help: "Current count of transactions not in a terminal state (finalized or fatal_error).",
+	promOldestNonTerminalTxAgeSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tx_manager_tx_oldest_non_terminal_age_seconds",
+		Help: "Age in seconds of the oldest evm.tx not in a terminal state (finalized or fatal_error); 0 if none. Useful for stuck-tx alerts (unlike a simple count, steady load can still show ~0 if txs complete quickly).",
 	}, []string{"chainID"})
 )
 
 type evmTxmMetrics struct {
 	metrics.GenericTXMMetrics
-	chainID                   string
-	numSuccessfulTxs          metric.Int64Counter
-	numRevertedTxs            metric.Int64Counter
-	fwdTxCount                metric.Int64Counter
-	txAttemptCount            metric.Float64Gauge
-	numFinalizedTxs           metric.Int64Counter
-	pendingTxQueueUtilization metric.Float64Gauge
-	nonTerminalTxCount        metric.Float64Gauge
+	chainID                       string
+	numSuccessfulTxs              metric.Int64Counter
+	numRevertedTxs                metric.Int64Counter
+	fwdTxCount                    metric.Int64Counter
+	txAttemptCount                metric.Float64Gauge
+	numFinalizedTxs               metric.Int64Counter
+	pendingTxQueueUtilization     metric.Float64Gauge
+	oldestNonTerminalTxAgeSeconds metric.Float64Gauge
 }
 
 func NewEVMTxmMetrics(chainID string) (*evmTxmMetrics, error) {
@@ -93,21 +93,21 @@ func NewEVMTxmMetrics(chainID string) (*evmTxmMetrics, error) {
 		return nil, fmt.Errorf("failed to register pending tx queue utilization: %w", err)
 	}
 
-	nonTerminalTxCount, err := beholder.GetMeter().Float64Gauge("tx_manager_transactions_non_terminal")
+	oldestNonTerminalTxAgeSeconds, err := beholder.GetMeter().Float64Gauge("tx_manager_tx_oldest_non_terminal_age_seconds")
 	if err != nil {
-		return nil, fmt.Errorf("failed to register non-terminal transaction count metric: %w", err)
+		return nil, fmt.Errorf("failed to register oldest non-terminal transaction age metric: %w", err)
 	}
 
 	return &evmTxmMetrics{
-		chainID:                   chainID,
-		GenericTXMMetrics:         genericTXMMetrics,
-		numSuccessfulTxs:          numSuccessfulTxs,
-		numRevertedTxs:            numRevertedTxs,
-		fwdTxCount:                fwdTxCount,
-		txAttemptCount:            txAttemptCount,
-		numFinalizedTxs:           numFinalizedTxs,
-		pendingTxQueueUtilization: pendingTxQueueUtilization,
-		nonTerminalTxCount:        nonTerminalTxCount,
+		chainID:                       chainID,
+		GenericTXMMetrics:             genericTXMMetrics,
+		numSuccessfulTxs:              numSuccessfulTxs,
+		numRevertedTxs:                numRevertedTxs,
+		fwdTxCount:                    fwdTxCount,
+		txAttemptCount:                txAttemptCount,
+		numFinalizedTxs:               numFinalizedTxs,
+		pendingTxQueueUtilization:     pendingTxQueueUtilization,
+		oldestNonTerminalTxAgeSeconds: oldestNonTerminalTxAgeSeconds,
 	}, nil
 }
 
@@ -144,7 +144,7 @@ func (m *evmTxmMetrics) AddNumFinalizedTxs(ctx context.Context, n int64) {
 	m.numFinalizedTxs.Add(ctx, n, metric.WithAttributes(attribute.String("chainID", m.chainID)))
 }
 
-func (m *evmTxmMetrics) RecordNonTerminalTxCount(ctx context.Context, count float64) {
-	promNonTerminalTxCount.WithLabelValues(m.chainID).Set(count)
-	m.nonTerminalTxCount.Record(ctx, count, metric.WithAttributes(attribute.String("chainID", m.chainID)))
+func (m *evmTxmMetrics) RecordOldestNonTerminalTxAgeSeconds(ctx context.Context, seconds float64) {
+	promOldestNonTerminalTxAgeSeconds.WithLabelValues(m.chainID).Set(seconds)
+	m.oldestNonTerminalTxAgeSeconds.Record(ctx, seconds, metric.WithAttributes(attribute.String("chainID", m.chainID)))
 }

--- a/pkg/txmgr/mocks/evm_tx_store.go
+++ b/pkg/txmgr/mocks/evm_tx_store.go
@@ -165,63 +165,6 @@ func (_c *EvmTxStore_Close_Call) RunAndReturn(run func()) *EvmTxStore_Close_Call
 	return _c
 }
 
-// CountNonTerminalTransactions provides a mock function with given fields: ctx, chainID
-func (_m *EvmTxStore) CountNonTerminalTransactions(ctx context.Context, chainID *big.Int) (uint32, error) {
-	ret := _m.Called(ctx, chainID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CountNonTerminalTransactions")
-	}
-
-	var r0 uint32
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) (uint32, error)); ok {
-		return rf(ctx, chainID)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) uint32); ok {
-		r0 = rf(ctx, chainID)
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, *big.Int) error); ok {
-		r1 = rf(ctx, chainID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// EvmTxStore_CountNonTerminalTransactions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountNonTerminalTransactions'
-type EvmTxStore_CountNonTerminalTransactions_Call struct {
-	*mock.Call
-}
-
-// CountNonTerminalTransactions is a helper method to define mock.On call
-//   - ctx context.Context
-//   - chainID *big.Int
-func (_e *EvmTxStore_Expecter) CountNonTerminalTransactions(ctx interface{}, chainID interface{}) *EvmTxStore_CountNonTerminalTransactions_Call {
-	return &EvmTxStore_CountNonTerminalTransactions_Call{Call: _e.mock.On("CountNonTerminalTransactions", ctx, chainID)}
-}
-
-func (_c *EvmTxStore_CountNonTerminalTransactions_Call) Run(run func(ctx context.Context, chainID *big.Int)) *EvmTxStore_CountNonTerminalTransactions_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*big.Int))
-	})
-	return _c
-}
-
-func (_c *EvmTxStore_CountNonTerminalTransactions_Call) Return(count uint32, err error) *EvmTxStore_CountNonTerminalTransactions_Call {
-	_c.Call.Return(count, err)
-	return _c
-}
-
-func (_c *EvmTxStore_CountNonTerminalTransactions_Call) RunAndReturn(run func(context.Context, *big.Int) (uint32, error)) *EvmTxStore_CountNonTerminalTransactions_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // CountTransactionsByState provides a mock function with given fields: ctx, state, chainID
 func (_m *EvmTxStore) CountTransactionsByState(ctx context.Context, state types.TxState, chainID *big.Int) (uint32, error) {
 	ret := _m.Called(ctx, state, chainID)
@@ -2395,6 +2338,63 @@ func (_c *EvmTxStore_LoadTxAttempts_Call) Return(_a0 error) *EvmTxStore_LoadTxAt
 }
 
 func (_c *EvmTxStore_LoadTxAttempts_Call) RunAndReturn(run func(context.Context, *types.Tx[*big.Int, common.Address, common.Hash, common.Hash, pkgtypes.Nonce, gas.EvmFee]) error) *EvmTxStore_LoadTxAttempts_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// OldestNonTerminalTxAgeSeconds provides a mock function with given fields: ctx, chainID
+func (_m *EvmTxStore) OldestNonTerminalTxAgeSeconds(ctx context.Context, chainID *big.Int) (float64, error) {
+	ret := _m.Called(ctx, chainID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OldestNonTerminalTxAgeSeconds")
+	}
+
+	var r0 float64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) (float64, error)); ok {
+		return rf(ctx, chainID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) float64); ok {
+		r0 = rf(ctx, chainID)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *big.Int) error); ok {
+		r1 = rf(ctx, chainID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EvmTxStore_OldestNonTerminalTxAgeSeconds_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OldestNonTerminalTxAgeSeconds'
+type EvmTxStore_OldestNonTerminalTxAgeSeconds_Call struct {
+	*mock.Call
+}
+
+// OldestNonTerminalTxAgeSeconds is a helper method to define mock.On call
+//   - ctx context.Context
+//   - chainID *big.Int
+func (_e *EvmTxStore_Expecter) OldestNonTerminalTxAgeSeconds(ctx interface{}, chainID interface{}) *EvmTxStore_OldestNonTerminalTxAgeSeconds_Call {
+	return &EvmTxStore_OldestNonTerminalTxAgeSeconds_Call{Call: _e.mock.On("OldestNonTerminalTxAgeSeconds", ctx, chainID)}
+}
+
+func (_c *EvmTxStore_OldestNonTerminalTxAgeSeconds_Call) Run(run func(ctx context.Context, chainID *big.Int)) *EvmTxStore_OldestNonTerminalTxAgeSeconds_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*big.Int))
+	})
+	return _c
+}
+
+func (_c *EvmTxStore_OldestNonTerminalTxAgeSeconds_Call) Return(seconds float64, err error) *EvmTxStore_OldestNonTerminalTxAgeSeconds_Call {
+	_c.Call.Return(seconds, err)
+	return _c
+}
+
+func (_c *EvmTxStore_OldestNonTerminalTxAgeSeconds_Call) RunAndReturn(run func(context.Context, *big.Int) (float64, error)) *EvmTxStore_OldestNonTerminalTxAgeSeconds_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/txmgr/mocks/evm_tx_store.go
+++ b/pkg/txmgr/mocks/evm_tx_store.go
@@ -165,6 +165,63 @@ func (_c *EvmTxStore_Close_Call) RunAndReturn(run func()) *EvmTxStore_Close_Call
 	return _c
 }
 
+// CountNonTerminalTransactions provides a mock function with given fields: ctx, chainID
+func (_m *EvmTxStore) CountNonTerminalTransactions(ctx context.Context, chainID *big.Int) (uint32, error) {
+	ret := _m.Called(ctx, chainID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountNonTerminalTransactions")
+	}
+
+	var r0 uint32
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) (uint32, error)); ok {
+		return rf(ctx, chainID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *big.Int) uint32); ok {
+		r0 = rf(ctx, chainID)
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *big.Int) error); ok {
+		r1 = rf(ctx, chainID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EvmTxStore_CountNonTerminalTransactions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountNonTerminalTransactions'
+type EvmTxStore_CountNonTerminalTransactions_Call struct {
+	*mock.Call
+}
+
+// CountNonTerminalTransactions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - chainID *big.Int
+func (_e *EvmTxStore_Expecter) CountNonTerminalTransactions(ctx interface{}, chainID interface{}) *EvmTxStore_CountNonTerminalTransactions_Call {
+	return &EvmTxStore_CountNonTerminalTransactions_Call{Call: _e.mock.On("CountNonTerminalTransactions", ctx, chainID)}
+}
+
+func (_c *EvmTxStore_CountNonTerminalTransactions_Call) Run(run func(ctx context.Context, chainID *big.Int)) *EvmTxStore_CountNonTerminalTransactions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*big.Int))
+	})
+	return _c
+}
+
+func (_c *EvmTxStore_CountNonTerminalTransactions_Call) Return(count uint32, err error) *EvmTxStore_CountNonTerminalTransactions_Call {
+	_c.Call.Return(count, err)
+	return _c
+}
+
+func (_c *EvmTxStore_CountNonTerminalTransactions_Call) RunAndReturn(run func(context.Context, *big.Int) (uint32, error)) *EvmTxStore_CountNonTerminalTransactions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountTransactionsByState provides a mock function with given fields: ctx, state, chainID
 func (_m *EvmTxStore) CountTransactionsByState(ctx context.Context, state types.TxState, chainID *big.Int) (uint32, error) {
 	ret := _m.Called(ctx, state, chainID)


### PR DESCRIPTION
More details in Jira, this PR addresses the subtasks:
- [Adjust logging of batch call context to exclude results](https://smartcontract-it.atlassian.net/browse/PLEX-2811)
- [Increment finalized tx counter only when we actually finalize transaction](https://smartcontract-it.atlassian.net/browse/PLEX-2813)
         - Additionally I noticed that we only ever increment this counter by 1 rather than by the number of tx hashes, I also addressed that
- [Create a metric for transactions that are stuck in non terminal state](https://smartcontract-it.atlassian.net/browse/PLEX-2814)
- [Dynamically adjust batch size limit in case of error](https://smartcontract-it.atlassian.net/browse/PLEX-2817)

[Create a dashboard and alert for tx_manager_transactions_non_terminal](https://smartcontract-it.atlassian.net/browse/PLEX-2850) will follow once this code is released.