### PR TITLE
DF-24352 new LimitDefault for Mantle after Arsia upgrade

### DIFF
--- a/pkg/config/toml/defaults/Mantle_Mainnet.toml
+++ b/pkg/config/toml/defaults/Mantle_Mainnet.toml
@@ -12,9 +12,6 @@ HistoryDepth = 1250
 
 [GasEstimator]
 PriceMax = '120 gwei'
-# Limit values are high as Mantle's GasPrice is in native token (MNT) instead of ETH. Their proprietary TokenRatio parameter is used to adjust fees
-LimitDefault = 80_000_000_000
-LimitMax = 100_000_000_000
 BumpMin = '100 wei'
 BumpThreshold = 60
 EIP1559DynamicFees = true

--- a/pkg/config/toml/defaults/Mantle_Sepolia.toml
+++ b/pkg/config/toml/defaults/Mantle_Sepolia.toml
@@ -12,11 +12,7 @@ HistoryDepth = 1250
 
 [GasEstimator]
 PriceMax = '120 gwei'
-# Limit values are high as Mantle's GasPrice is in native token (MNT) instead of ETH. Their proprietary TokenRatio parameter is used to adjust fees
-LimitDefault = 80000000000
-LimitMax = 100000000000
 BumpMin = '100 wei'
-BumpPercent = 20
 BumpThreshold = 60
 EIP1559DynamicFees = true
 FeeCapDefault = '120 gwei'


### PR DESCRIPTION
Following the Mantle Arsia upgrade, `eth_estimateGas` now returns pure L2 execution gas (no amortised L1 data costs anymore). Our transactions use about ~117,600. After [INCIDENT-2427](https://smartcontract-it.atlassian.net/browse/INCIDENT-2427) NOPs overrode `LimitDefault` to `500_000`.

Still a ~4× overestimate but nothing that would cause issues, and is in line with other EVMs so for consistency that's what we're picking here.

- `BumpPercent` (`20`) dominates over `BumpMin` - no point in changing it.
- Removed useless `BumpPercent` chain-override for testnet.
- `LimitMax` isn't used in `BlockHistoryEstimator` - its presence is misleading, so removed.

<!--- Does this work have a corresponding ticket?  Please link it here as well as one of:
    - the PR title
    - branch name
    - commit message
[LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires
<!--- Does this work depend on other open PRs? Please list them.
- https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Supports
- https://github.com/smartcontractkit/chainlink/pull/22252
<!--- Does this work support other open PRs?  Please list them.
-->


[INCIDENT-2427]: https://smartcontract-it.atlassian.net/browse/INCIDENT-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ