### PR TITLE
try to fix clean up deadlock in logpoller

### DIFF
--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -522,9 +522,15 @@ func (lp *logPoller) savedFinalizedBlockNumber(ctx context.Context) (int64, erro
 
 func (lp *logPoller) recvReplayComplete() {
 	defer lp.wg.Done()
-	err := <-lp.replayComplete
-	if err != nil {
-		lp.lggr.Error(err)
+	// Also listen on stopCh: if Close runs before run loop produces a replayComplete
+	// value (e.g. a concurrent Replay observed ctx.Done at the same instant the run
+	// loop did and produced no completion), wait would block forever.
+	select {
+	case err := <-lp.replayComplete:
+		if err != nil {
+			lp.lggr.Error(err)
+		}
+	case <-lp.stopCh:
 	}
 }
 

--- a/pkg/logpoller/log_poller_internal_test.go
+++ b/pkg/logpoller/log_poller_internal_test.go
@@ -713,6 +713,39 @@ func TestLogPoller_Replay(t *testing.T) {
 	})
 }
 
+// TestLogPoller_Close_RecvReplayComplete_NoDeadlock is a regression test for the scenario
+// where Close() hangs in wg.Wait() because recvReplayComplete blocks forever on <-replayComplete.
+//
+// Sequence that previously deadlocked:
+//  1. Replay's ctx fires Done → Replay spawns recvReplayComplete (wg.Add(1)) and returns ErrReplayInProgress.
+//  2. Close's single non-blocking send to replayComplete fires to default (recvReplayComplete not yet receiving).
+//  3. close(stopCh) then wg.Wait() — recvReplayComplete blocks on <-replayComplete forever, wg never drains.
+//
+// Fix: recvReplayComplete also selects on stopCh so it exits when the poller shuts down.
+func TestLogPoller_Close_RecvReplayComplete_NoDeadlock(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.Test(t)
+	lp := NewLogPoller(nil, nil, lggr, nil, Opts{PollPeriod: time.Hour})
+
+	// Reproduce the race: Close's non-blocking send already went to default before
+	// recvReplayComplete was scheduled, then stopCh was closed. No replayComplete value
+	// will ever arrive; recvReplayComplete must exit via stopCh or wg.Wait() hangs.
+	close(lp.stopCh)
+
+	lp.wg.Add(1)
+	go lp.recvReplayComplete()
+
+	done := make(chan struct{})
+	go func() { lp.wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("recvReplayComplete blocked on <-replayComplete after stopCh closed; Close() would deadlock")
+	}
+}
+
 func (lp *logPoller) reset() {
 	lp.StateMachine = services.StateMachine{}
 	lp.stopCh = make(chan struct{})


### PR DESCRIPTION
Made with AI and explained as:
```
  That said, the fix is mechanically sufficient: recvReplayComplete now also selects on lp.stopCh, so when Close() runs close(lp.stopCh) and then wg.Wait(), every recvReplayComplete goroutine — whether spawned before or after close(stopCh) — observes the closed channel and exits. The previous "send must arrive before
  goroutine starts receiving" timing dependence is gone.
```

Hoping to solve deadlocks like this one, which are endemic in `chainlink` repo:
```
    FAIL    github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider    900.816s

    === Failed
    === FAIL: core/services/llo/telem TestSample (0.00s)
        sampling_test.go:140:
                Error Trace:    /home/runner/_work/chainlink/chainlink/core/services/llo/telem/sampling_test.go:140
                Error:          Should be false
                Test:           TestSample

    === FAIL: core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider  (0.00s)
    panic: test timed out after 15m0s
        running tests:
            TestIntegration_LogEventProvider_UpdateConfig (14m53s)
```

or

```
     === FAIL: core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider
     (0.00s)
     panic: test timed out after 15m0s
        running tests:
                TestIntegration_LogEventProvider_Backfill (14m52s)

     goroutine 93719 [running]:
     testing.(*M).startAlarm.func1()
        /opt/hostedtoolcache/go/1.26.2/x64/src/testing/testing.go:2802 +0x34b
     created by time.goFunc
        /opt/hostedtoolcache/go/1.26.2/x64/src/time/sleep.go:215 +0x2d
```

Chainlink PR: https://github.com/smartcontractkit/chainlink/pull/22337
So far [10 successful re-runs:](https://github.com/smartcontractkit/chainlink/actions/runs/25488891367)
<img width="275" height="736" alt="image" src="https://github.com/user-attachments/assets/d362f2e1-211e-4307-9ee2-56786a097ea0" />