### PR TITLE
DF-23700 harmonize rpc client metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20251022073203-7d8ae8cf67c1
 	github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20260423135514-5b1a7565a99c
 	github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260423135514-5b1a7565a99c
-	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260423135514-5b1a7565a99c
+	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260508154216-3ed6f623098f
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20260505202410-b350dca113b4
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260326111235-8c09d1a4491f
 	github.com/smartcontractkit/chainlink-protos/svr v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -638,8 +638,8 @@ github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-202604231355
 github.com/smartcontractkit/chainlink-framework/capabilities v0.0.0-20260423135514-5b1a7565a99c/go.mod h1:HcwehCao5k5C2NGuKJUVoX/AYtoH6njGFiV44dBOcY4=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260423135514-5b1a7565a99c h1:0c+bCKo47vy/ItRtGa3S/vCpE5LRlgXpGnVKQX8TgjE=
 github.com/smartcontractkit/chainlink-framework/chains v0.0.0-20260423135514-5b1a7565a99c/go.mod h1:kGprqyjsz6qFNVszOQoHc24wfvCjyipNZFste/3zcbs=
-github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260423135514-5b1a7565a99c h1:1VVreRcffo3N3zF1JVtgS+YC4puuj3y0FU0Fta7L3U0=
-github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260423135514-5b1a7565a99c/go.mod h1:HG/aei0MgBOpsyRLexdKGtOUO8yjSJO3iUu0Uu8KBm4=
+github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260508154216-3ed6f623098f h1:C6eGGsdTVyB3mtz1VF/o9Znshwrr/VkKsLYGinOVM/k=
+github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260508154216-3ed6f623098f/go.mod h1:HG/aei0MgBOpsyRLexdKGtOUO8yjSJO3iUu0Uu8KBm4=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20260505202410-b350dca113b4 h1:nXU0s4WAVU2cAR76Ke7h9z55NuEtRq1WvT4wVEs7jwk=
 github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20260505202410-b350dca113b4/go.mod h1:7ketk4ischPQW/JQgmyHz6zdzLUJv1VC29SiSgosydQ=
 github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260326111235-8c09d1a4491f h1:8p3vE987AHM3Of1JvnNJXNE/AtWtfNvJhk3TeeAG3Qw=

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -180,18 +180,12 @@ func NewRPCClient(
 		lggr.Error("RPC client is configured with only WebSocket URL. If this CL Node serves external requests, it must also have an HTTP URL configured. Otherwise, there is a serious DDoS risk.")
 	}
 
-	var rpcURL string
-	if wsuri != nil {
-		rpcURL = wsuri.String()
-	} else if httpuri != nil {
-		rpcURL = httpuri.String()
-	}
 	isSendOnly := tier == multinode.Secondary
 	var rpcBaseMetrics frameworkmetrics.RPCClientMetrics
 	if r.beholderMetrics != nil {
 		rpcBaseMetrics = r.beholderMetrics.rpcClientMetrics
 	}
-	r.RPCClientBase = multinode.NewRPCClientBase[*evmtypes.Head](cfg, QueryTimeout, lggr, r.latestBlock, r.latestFinalizedBlock, rpcURL, isSendOnly, rpcBaseMetrics)
+	r.RPCClientBase = multinode.NewRPCClientBase[*evmtypes.Head](cfg, QueryTimeout, lggr, r.latestBlock, r.latestFinalizedBlock, r.getRPCDomain(), isSendOnly, rpcBaseMetrics)
 	return r
 }
 
@@ -341,7 +335,11 @@ func (r *RPCClient) getRPCDomain() string {
 	if http != nil {
 		return http.uri.Host
 	}
-	return r.ws.Load().uri.Host
+	ws := r.ws.Load()
+	if ws != nil {
+		return ws.uri.Host
+	}
+	return ""
 }
 
 func (r *RPCClient) isChainType(chainType chaintype.ChainType) bool {


### PR DESCRIPTION
Pass the rpc domain to RPCClientBase, not the url, for consistency.

Bump `chainlink-framework/metrics`. Brings better labels and sanitization (https://github.com/smartcontractkit/chainlink-framework/pull/106)