### PR TITLE
Increase gas price limit for Ronin

### DIFF
--- a/pkg/config/toml/defaults/Ronin_Mainnet.toml
+++ b/pkg/config/toml/defaults/Ronin_Mainnet.toml
@@ -9,7 +9,7 @@ LinkContractAddress = '0x3902228D6A3d2Dc44731fD9d45FeE6a61c722D0b'
 [GasEstimator]
 EIP1559DynamicFees = true
 Mode = "FeeHistory"
-PriceMax = "120 gwei"
+PriceMax = "1000 gwei"
 
 [GasEstimator.BlockHistory]
 BlockHistorySize = 60

--- a/pkg/config/toml/defaults/Ronin_Saigon.toml
+++ b/pkg/config/toml/defaults/Ronin_Saigon.toml
@@ -9,7 +9,7 @@ LinkContractAddress = '0x5bB50A6888ee6a67E22afFDFD9513be7740F1c15'
 [GasEstimator]
 EIP1559DynamicFees = true
 Mode = "FeeHistory"
-PriceMax = "120 gwei"
+PriceMax = "1000 gwei"
 
 [GasEstimator.BlockHistory]
 BlockHistorySize = 60


### PR DESCRIPTION
This PR changes max Gas Price back to 1000 gwei. After a recent chain upgrade, we had to update Ronin's configs, including the max price. The previous value was aligned with CCIP's, however CCIP has different inclusion requirements so for feeds we should re-use the old ceiling instead.