### PR TITLE
Update arbitrum gas estimator's settings

### DIFF
--- a/pkg/gas/arbitrum_estimator.go
+++ b/pkg/gas/arbitrum_estimator.go
@@ -54,7 +54,7 @@ func NewArbitrumEstimator(lggr logger.Logger, cfg ArbConfig, ethClient FeeEstima
 
 	return &arbitrumEstimator{
 		cfg:            cfg,
-		EvmEstimator:   NewSuggestedPriceEstimator(lggr, ethClient, cfg, l1Oracle, chaintype.ChainArbitrum),
+		EvmEstimator:   NewSuggestedPriceEstimator(lggr, ethClient, cfg, chaintype.ChainArbitrum, l1Oracle),
 		pollPeriod:     arbitrumPollPeriod,
 		logger:         lggr,
 		chForceRefetch: make(chan (chan struct{})),

--- a/pkg/gas/arbitrum_estimator.go
+++ b/pkg/gas/arbitrum_estimator.go
@@ -52,7 +52,7 @@ func NewArbitrumEstimator(lggr logger.Logger, cfg ArbConfig, ethClient FeeEstima
 	return &arbitrumEstimator{
 		cfg:            cfg,
 		EvmEstimator:   NewSuggestedPriceEstimator(lggr, ethClient, cfg, l1Oracle),
-		pollPeriod:     10 * time.Second,
+		pollPeriod:     2 * time.Second,
 		logger:         lggr,
 		chForceRefetch: make(chan (chan struct{})),
 		chInitialised:  make(chan struct{}),
@@ -153,7 +153,7 @@ func (a *arbitrumEstimator) GetMaxLegacyGas(ctx context.Context, calldata []byte
 // the block's base fee. If the base fee increases rapidly there is a chance the suggested gas price will fall under that value, resulting in a fee too low error.
 // We use gasPriceWithBuffer to increase the estimated gas price by some percentage to avoid fee too low errors. Eventually, only the base fee will be paid, regardless of the price.
 func (a *arbitrumEstimator) gasPriceWithBuffer(gasPrice *assets.Wei, maxGasPriceWei *assets.Wei) *assets.Wei {
-	const gasPriceBufferPercentage = 50
+	const gasPriceBufferPercentage = 75
 
 	gasPrice = gasPrice.AddPercentage(gasPriceBufferPercentage)
 	if gasPrice.Cmp(maxGasPriceWei) > 0 {

--- a/pkg/gas/arbitrum_estimator.go
+++ b/pkg/gas/arbitrum_estimator.go
@@ -46,15 +46,15 @@ type arbitrumEstimator struct {
 	l1Oracle rollups.ArbL1GasOracle
 }
 
-const pollPeriod = 2 * time.Second
+const arbitrumPollPeriod = 2 * time.Second
 
 func NewArbitrumEstimator(lggr logger.Logger, cfg ArbConfig, ethClient FeeEstimatorClient, l1Oracle rollups.ArbL1GasOracle) EvmEstimator {
 	lggr = logger.Named(lggr, "ArbitrumEstimator")
 
 	return &arbitrumEstimator{
 		cfg:            cfg,
-		EvmEstimator:   NewSuggestedPriceEstimatorWithPollPeriod(lggr, ethClient, cfg, l1Oracle, pollPeriod),
-		pollPeriod:     pollPeriod,
+		EvmEstimator:   NewSuggestedPriceEstimatorWithPollPeriod(lggr, ethClient, cfg, l1Oracle, arbitrumPollPeriod),
+		pollPeriod:     arbitrumPollPeriod,
 		logger:         lggr,
 		chForceRefetch: make(chan (chan struct{})),
 		chInitialised:  make(chan struct{}),

--- a/pkg/gas/arbitrum_estimator.go
+++ b/pkg/gas/arbitrum_estimator.go
@@ -156,7 +156,7 @@ func (a *arbitrumEstimator) GetMaxLegacyGas(ctx context.Context, calldata []byte
 // the block's base fee. If the base fee increases rapidly there is a chance the suggested gas price will fall under that value, resulting in a fee too low error.
 // We use gasPriceWithBuffer to increase the estimated gas price by some percentage to avoid fee too low errors. Eventually, only the base fee will be paid, regardless of the price.
 func (a *arbitrumEstimator) gasPriceWithBuffer(gasPrice *assets.Wei, maxGasPriceWei *assets.Wei) *assets.Wei {
-	const gasPriceBufferPercentage = 75
+	const gasPriceBufferPercentage = 90
 
 	gasPrice = gasPrice.AddPercentage(gasPriceBufferPercentage)
 	if gasPrice.Cmp(maxGasPriceWei) > 0 {

--- a/pkg/gas/arbitrum_estimator.go
+++ b/pkg/gas/arbitrum_estimator.go
@@ -46,13 +46,15 @@ type arbitrumEstimator struct {
 	l1Oracle rollups.ArbL1GasOracle
 }
 
+const pollPeriod = 2 * time.Second
+
 func NewArbitrumEstimator(lggr logger.Logger, cfg ArbConfig, ethClient FeeEstimatorClient, l1Oracle rollups.ArbL1GasOracle) EvmEstimator {
 	lggr = logger.Named(lggr, "ArbitrumEstimator")
 
 	return &arbitrumEstimator{
 		cfg:            cfg,
-		EvmEstimator:   NewSuggestedPriceEstimator(lggr, ethClient, cfg, l1Oracle),
-		pollPeriod:     2 * time.Second,
+		EvmEstimator:   NewSuggestedPriceEstimatorWithPollPeriod(lggr, ethClient, cfg, l1Oracle, pollPeriod),
+		pollPeriod:     pollPeriod,
 		logger:         lggr,
 		chForceRefetch: make(chan (chan struct{})),
 		chInitialised:  make(chan struct{}),
@@ -96,7 +98,7 @@ func (a *arbitrumEstimator) HealthReport() map[string]error {
 // GetLegacyGas estimates both the gas price and the gas limit.
 //   - Price is delegated to the embedded SuggestedPriceEstimator.
 //   - Limit is computed from the dynamic values perL2Tx and perL1CalldataUnit, provided by the getPricesInArbGas() method
-//     of the precompilie contract at ArbGasInfoAddress. perL2Tx is a constant amount of gas, and perL1CalldataUnit is
+//     of the precompile contract at ArbGasInfoAddress. perL2Tx is a constant amount of gas, and perL1CalldataUnit is
 //     multiplied by the length of the tx calldata. The sum of these two values plus the original l2GasLimit is returned.
 func (a *arbitrumEstimator) GetLegacyGas(ctx context.Context, calldata []byte, l2GasLimit uint64, maxGasPriceWei *assets.Wei, opts ...fees.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint64, err error) {
 	gasPrice, _, err = a.EvmEstimator.GetLegacyGas(ctx, calldata, l2GasLimit, maxGasPriceWei, opts...)

--- a/pkg/gas/arbitrum_estimator.go
+++ b/pkg/gas/arbitrum_estimator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-framework/chains/fees"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas/rollups"
 )
 
@@ -53,7 +54,7 @@ func NewArbitrumEstimator(lggr logger.Logger, cfg ArbConfig, ethClient FeeEstima
 
 	return &arbitrumEstimator{
 		cfg:            cfg,
-		EvmEstimator:   NewSuggestedPriceEstimatorWithPollPeriod(lggr, ethClient, cfg, l1Oracle, arbitrumPollPeriod),
+		EvmEstimator:   NewSuggestedPriceEstimator(lggr, ethClient, cfg, l1Oracle, chaintype.ChainArbitrum),
 		pollPeriod:     arbitrumPollPeriod,
 		logger:         lggr,
 		chForceRefetch: make(chan (chan struct{})),

--- a/pkg/gas/arbitrum_estimator_test.go
+++ b/pkg/gas/arbitrum_estimator_test.go
@@ -49,7 +49,7 @@ func TestArbitrumEstimator(t *testing.T) {
 	const maxGasLimit uint64 = 500_000
 	calldata := []byte{0x00, 0x00, 0x01, 0x02, 0x03}
 	const gasLimit uint64 = 80000
-	const gasPriceBufferPercentage = 50
+	const gasPriceBufferPercentage = 75
 	const bumpPercent = 10
 	var bumpMin = assets.NewWei(big.NewInt(1))
 
@@ -235,7 +235,7 @@ func TestArbitrumEstimator(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, gasPrice)
 		// Again, a normal l2_suggested_estimator would return 42, but arbitrum_estimator adds a buffer.
-		assert.Equal(t, "63 wei", gasPrice.String())
+		assert.Equal(t, "73 wei", gasPrice.String())
 		assert.Equal(t, expLimit, chainSpecificGasLimit, "expected %d but got %d", expLimit, chainSpecificGasLimit)
 	})
 

--- a/pkg/gas/arbitrum_estimator_test.go
+++ b/pkg/gas/arbitrum_estimator_test.go
@@ -49,7 +49,7 @@ func TestArbitrumEstimator(t *testing.T) {
 	const maxGasLimit uint64 = 500_000
 	calldata := []byte{0x00, 0x00, 0x01, 0x02, 0x03}
 	const gasLimit uint64 = 80000
-	const gasPriceBufferPercentage = 75
+	const gasPriceBufferPercentage = 90
 	const bumpPercent = 10
 	var bumpMin = assets.NewWei(big.NewInt(1))
 
@@ -235,7 +235,7 @@ func TestArbitrumEstimator(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, gasPrice)
 		// Again, a normal l2_suggested_estimator would return 42, but arbitrum_estimator adds a buffer.
-		assert.Equal(t, "73 wei", gasPrice.String())
+		assert.Equal(t, "79 wei", gasPrice.String())
 		assert.Equal(t, expLimit, chainSpecificGasLimit, "expected %d but got %d", expLimit, chainSpecificGasLimit)
 	})
 

--- a/pkg/gas/models.go
+++ b/pkg/gas/models.go
@@ -100,7 +100,7 @@ func NewEstimator(lggr logger.Logger, ethClient FeeEstimatorClient, chaintype ch
 	case "FixedPrice":
 		newEstimator = NewFixedPriceEstimator(geCfg, ethClient, bh.EIP1559FeeCapBufferBlocks(), lggr, l1Oracle)
 	case "L2Suggested", "SuggestedPrice":
-		newEstimator = NewSuggestedPriceEstimator(lggr, ethClient, geCfg, l1Oracle)
+		newEstimator = NewSuggestedPriceEstimator(lggr, ethClient, geCfg, l1Oracle, chaintype)
 	case "FeeHistory":
 		ccfg := FeeHistoryEstimatorConfig{
 			BumpPercent:      geCfg.BumpPercent(),

--- a/pkg/gas/models.go
+++ b/pkg/gas/models.go
@@ -100,7 +100,7 @@ func NewEstimator(lggr logger.Logger, ethClient FeeEstimatorClient, chaintype ch
 	case "FixedPrice":
 		newEstimator = NewFixedPriceEstimator(geCfg, ethClient, bh.EIP1559FeeCapBufferBlocks(), lggr, l1Oracle)
 	case "L2Suggested", "SuggestedPrice":
-		newEstimator = NewSuggestedPriceEstimator(lggr, ethClient, geCfg, l1Oracle, chaintype)
+		newEstimator = NewSuggestedPriceEstimator(lggr, ethClient, geCfg, chaintype, l1Oracle)
 	case "FeeHistory":
 		ccfg := FeeHistoryEstimatorConfig{
 			BumpPercent:      geCfg.BumpPercent(),

--- a/pkg/gas/suggested_price_estimator.go
+++ b/pkg/gas/suggested_price_estimator.go
@@ -63,6 +63,11 @@ func NewSuggestedPriceEstimator(lggr logger.Logger, client FeeEstimatorClient, c
 
 // NewSuggestedPriceEstimatorWithPollPeriod returns a new Estimator which uses the suggested gas price, polling at the given interval.
 func NewSuggestedPriceEstimatorWithPollPeriod(lggr logger.Logger, client FeeEstimatorClient, cfg suggestedPriceConfig, l1Oracle rollups.L1Oracle, pollPeriod time.Duration) EvmEstimator {
+	if pollPeriod <= 0 {
+		pollPeriod = defaultPollPeriod
+	}
+
+	lggr.Infof("Creating SuggestedPriceEstimator with poll period: %s", pollPeriod)
 	return &SuggestedPriceEstimator{
 		client:         client,
 		pollPeriod:     pollPeriod,

--- a/pkg/gas/suggested_price_estimator.go
+++ b/pkg/gas/suggested_price_estimator.go
@@ -67,7 +67,7 @@ func NewSuggestedPriceEstimatorWithPollPeriod(lggr logger.Logger, client FeeEsti
 		pollPeriod = defaultPollPeriod
 	}
 
-	lggr.Infof("Creating SuggestedPriceEstimator with poll period: %s", pollPeriod)
+	lggr.Infow("Creating SuggestedPriceEstimator", "pollPeriod", pollPeriod)
 	return &SuggestedPriceEstimator{
 		client:         client,
 		pollPeriod:     pollPeriod,

--- a/pkg/gas/suggested_price_estimator.go
+++ b/pkg/gas/suggested_price_estimator.go
@@ -58,7 +58,7 @@ type SuggestedPriceEstimator struct {
 const defaultPollPeriod = 10 * time.Second
 
 // NewSuggestedPriceEstimator returns a new Estimator which uses the suggested gas price.
-func NewSuggestedPriceEstimator(lggr logger.Logger, client FeeEstimatorClient, cfg suggestedPriceConfig, l1Oracle rollups.L1Oracle, chainType chaintype.ChainType) EvmEstimator {
+func NewSuggestedPriceEstimator(lggr logger.Logger, client FeeEstimatorClient, cfg suggestedPriceConfig, chainType chaintype.ChainType, l1Oracle rollups.L1Oracle) EvmEstimator {
 	pollPeriod := defaultPollPeriod
 	if chainType == chaintype.ChainArbitrum {
 		pollPeriod = arbitrumPollPeriod

--- a/pkg/gas/suggested_price_estimator.go
+++ b/pkg/gas/suggested_price_estimator.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas/rollups"
 	"github.com/smartcontractkit/chainlink-evm/pkg/types"
 	"github.com/smartcontractkit/chainlink-framework/chains/fees"
@@ -57,14 +58,10 @@ type SuggestedPriceEstimator struct {
 const defaultPollPeriod = 10 * time.Second
 
 // NewSuggestedPriceEstimator returns a new Estimator which uses the suggested gas price.
-func NewSuggestedPriceEstimator(lggr logger.Logger, client FeeEstimatorClient, cfg suggestedPriceConfig, l1Oracle rollups.L1Oracle) EvmEstimator {
-	return NewSuggestedPriceEstimatorWithPollPeriod(lggr, client, cfg, l1Oracle, defaultPollPeriod)
-}
-
-// NewSuggestedPriceEstimatorWithPollPeriod returns a new Estimator which uses the suggested gas price, polling at the given interval.
-func NewSuggestedPriceEstimatorWithPollPeriod(lggr logger.Logger, client FeeEstimatorClient, cfg suggestedPriceConfig, l1Oracle rollups.L1Oracle, pollPeriod time.Duration) EvmEstimator {
-	if pollPeriod <= 0 {
-		pollPeriod = defaultPollPeriod
+func NewSuggestedPriceEstimator(lggr logger.Logger, client FeeEstimatorClient, cfg suggestedPriceConfig, l1Oracle rollups.L1Oracle, chainType chaintype.ChainType) EvmEstimator {
+	pollPeriod := defaultPollPeriod
+	if chainType == chaintype.ChainArbitrum {
+		pollPeriod = arbitrumPollPeriod
 	}
 
 	lggr.Infow("Creating SuggestedPriceEstimator", "pollPeriod", pollPeriod)

--- a/pkg/gas/suggested_price_estimator.go
+++ b/pkg/gas/suggested_price_estimator.go
@@ -54,11 +54,18 @@ type SuggestedPriceEstimator struct {
 	l1Oracle rollups.L1Oracle
 }
 
+const defaultPollPeriod = 10 * time.Second
+
 // NewSuggestedPriceEstimator returns a new Estimator which uses the suggested gas price.
 func NewSuggestedPriceEstimator(lggr logger.Logger, client FeeEstimatorClient, cfg suggestedPriceConfig, l1Oracle rollups.L1Oracle) EvmEstimator {
+	return NewSuggestedPriceEstimatorWithPollPeriod(lggr, client, cfg, l1Oracle, defaultPollPeriod)
+}
+
+// NewSuggestedPriceEstimatorWithPollPeriod returns a new Estimator which uses the suggested gas price, polling at the given interval.
+func NewSuggestedPriceEstimatorWithPollPeriod(lggr logger.Logger, client FeeEstimatorClient, cfg suggestedPriceConfig, l1Oracle rollups.L1Oracle, pollPeriod time.Duration) EvmEstimator {
 	return &SuggestedPriceEstimator{
 		client:         client,
-		pollPeriod:     10 * time.Second,
+		pollPeriod:     pollPeriod,
 		logger:         logger.Named(lggr, "SuggestedPriceEstimator"),
 		cfg:            cfg,
 		chForceRefetch: make(chan (chan struct{})),

--- a/pkg/gas/suggested_price_estimator_test.go
+++ b/pkg/gas/suggested_price_estimator_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
-	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas/mocks"
 	rollupMocks "github.com/smartcontractkit/chainlink-evm/pkg/gas/rollups/mocks"
@@ -35,7 +34,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 		_, _, err := o.GetLegacyGas(tests.Context(t), calldata, gasLimit, maxGasPrice)
 		assert.EqualError(t, err, "estimator is not started")
 	})
@@ -49,7 +48,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 			(*big.Int)(res).SetInt64(42)
 		})
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 		servicetest.RunHealthy(t, o)
 		gasPrice, chainSpecificGasLimit, err := o.GetLegacyGas(tests.Context(t), calldata, gasLimit, maxGasPrice)
 		require.NoError(t, err)
@@ -61,7 +60,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)
@@ -80,7 +79,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)
@@ -98,7 +97,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(pkgerrors.New("kaboom"))
 
@@ -112,7 +111,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 		_, err := o.GetDynamicFee(tests.Context(t), maxGasPrice)
 		assert.EqualError(t, err, "dynamic fees are not implemented for this estimator")
 	})
@@ -121,7 +120,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 		_, _, err := o.BumpLegacyGas(tests.Context(t), assets.NewWeiI(42), gasLimit, maxGasPrice, nil)
 		assert.EqualError(t, err, "estimator is not started")
 	})
@@ -130,7 +129,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 		fee := gas.DynamicFee{
 			GasFeeCap: assets.NewWeiI(42),
 			GasTipCap: assets.NewWeiI(5),
@@ -148,7 +147,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 			(*big.Int)(res).SetInt64(40)
 		})
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 		servicetest.RunHealthy(t, o)
 		gasPrice, chainSpecificGasLimit, err := o.BumpLegacyGas(tests.Context(t), assets.NewWeiI(10), gasLimit, maxGasPrice, nil)
 		require.NoError(t, err)
@@ -166,7 +165,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		})
 
 		testCfg := &gas.MockGasEstimatorConfig{BumpPercentF: 1, BumpMinF: assets.NewWei(big.NewInt(1)), BumpThresholdF: 1, LimitMultiplierF: 1}
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, testCfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, testCfg, "", l1Oracle)
 		servicetest.RunHealthy(t, o)
 		gasPrice, chainSpecificGasLimit, err := o.BumpLegacyGas(tests.Context(t), assets.NewWeiI(10), gasLimit, maxGasPrice, nil)
 		require.NoError(t, err)
@@ -183,7 +182,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 			(*big.Int)(res).SetInt64(5)
 		})
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 		servicetest.RunHealthy(t, o)
 		gasPrice, chainSpecificGasLimit, err := o.BumpLegacyGas(tests.Context(t), assets.NewWeiI(10), gasLimit, maxGasPrice, nil)
 		require.NoError(t, err)
@@ -195,7 +194,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)
@@ -214,7 +213,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)
@@ -232,7 +231,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(pkgerrors.New("kaboom"))
 
@@ -246,7 +245,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, "", l1Oracle)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)

--- a/pkg/gas/suggested_price_estimator_test.go
+++ b/pkg/gas/suggested_price_estimator_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
+	"github.com/smartcontractkit/chainlink-evm/pkg/config/chaintype"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas/mocks"
 	rollupMocks "github.com/smartcontractkit/chainlink-evm/pkg/gas/rollups/mocks"
@@ -34,7 +35,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 		_, _, err := o.GetLegacyGas(tests.Context(t), calldata, gasLimit, maxGasPrice)
 		assert.EqualError(t, err, "estimator is not started")
 	})
@@ -48,7 +49,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 			(*big.Int)(res).SetInt64(42)
 		})
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 		servicetest.RunHealthy(t, o)
 		gasPrice, chainSpecificGasLimit, err := o.GetLegacyGas(tests.Context(t), calldata, gasLimit, maxGasPrice)
 		require.NoError(t, err)
@@ -60,7 +61,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)
@@ -79,7 +80,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)
@@ -97,7 +98,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(pkgerrors.New("kaboom"))
 
@@ -111,7 +112,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 		_, err := o.GetDynamicFee(tests.Context(t), maxGasPrice)
 		assert.EqualError(t, err, "dynamic fees are not implemented for this estimator")
 	})
@@ -120,7 +121,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 		_, _, err := o.BumpLegacyGas(tests.Context(t), assets.NewWeiI(42), gasLimit, maxGasPrice, nil)
 		assert.EqualError(t, err, "estimator is not started")
 	})
@@ -129,7 +130,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 		fee := gas.DynamicFee{
 			GasFeeCap: assets.NewWeiI(42),
 			GasTipCap: assets.NewWeiI(5),
@@ -147,7 +148,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 			(*big.Int)(res).SetInt64(40)
 		})
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 		servicetest.RunHealthy(t, o)
 		gasPrice, chainSpecificGasLimit, err := o.BumpLegacyGas(tests.Context(t), assets.NewWeiI(10), gasLimit, maxGasPrice, nil)
 		require.NoError(t, err)
@@ -165,7 +166,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		})
 
 		testCfg := &gas.MockGasEstimatorConfig{BumpPercentF: 1, BumpMinF: assets.NewWei(big.NewInt(1)), BumpThresholdF: 1, LimitMultiplierF: 1}
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, testCfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, testCfg, l1Oracle, chaintype.ChainOptimismBedrock)
 		servicetest.RunHealthy(t, o)
 		gasPrice, chainSpecificGasLimit, err := o.BumpLegacyGas(tests.Context(t), assets.NewWeiI(10), gasLimit, maxGasPrice, nil)
 		require.NoError(t, err)
@@ -182,7 +183,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 			(*big.Int)(res).SetInt64(5)
 		})
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 		servicetest.RunHealthy(t, o)
 		gasPrice, chainSpecificGasLimit, err := o.BumpLegacyGas(tests.Context(t), assets.NewWeiI(10), gasLimit, maxGasPrice, nil)
 		require.NoError(t, err)
@@ -194,7 +195,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)
@@ -213,7 +214,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)
@@ -231,7 +232,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(pkgerrors.New("kaboom"))
 
@@ -245,7 +246,7 @@ func TestSuggestedPriceEstimator(t *testing.T) {
 		feeEstimatorClient := mocks.NewFeeEstimatorClient(t)
 		l1Oracle := rollupMocks.NewL1Oracle(t)
 
-		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle)
+		o := gas.NewSuggestedPriceEstimator(logger.Test(t), feeEstimatorClient, cfg, l1Oracle, chaintype.ChainOptimismBedrock)
 
 		feeEstimatorClient.On("CallContext", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
 			res := args.Get(1).(*hexutil.Big)


### PR DESCRIPTION
## What 

Update arbitrum gas estimator settings:
* refresh interval: 10s -> 2s
* gas bump 1.5x -> 1.9x

## Why

Basically, there's no higher bound on arbitrum's block-over-block base fee increases, so to deal with that better we shorten the refresh interval and increase the bump percentage. 