### PR TITLE
Sanitize rpc errors

### DIFF
--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -1412,6 +1412,16 @@ func (r *RPCClient) prepareCallArgs(msg ethereum.CallMsg) interface{} {
 	return toBackwardCompatibleCallArgWithChainTypeSupport(msg, r.chainType)
 }
 
+// Matches URLs and captures only the scheme + host, allowing path segments (e.g. API keys) to be stripped via replacement with "$1/".
+var rpcURLPathRegexp = regexp.MustCompile(`(https?://[^/\s"']+)/[^"'\s]*`)
+
+func sanitizeRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return errors.New(rpcURLPathRegexp.ReplaceAllString(err.Error(), "$1/"))
+}
+
 func (r *RPCClient) wrapRPCClientError(err error) error {
 	if err == nil {
 		r.rpcLog.Trace("Call succeeded")
@@ -1420,6 +1430,11 @@ func (r *RPCClient) wrapRPCClientError(err error) error {
 	if pkgerrors.Cause(err).Error() == "context deadline exceeded" {
 		err = pkgerrors.Wrap(err, "remote node timed out")
 	}
+
+	// Convert to a sanitized string error before logging or returning.
+	// This prevents provider API keys embedded in URL paths from leaking.
+	err = sanitizeRPCError(err)
+
 	r.rpcLog.Infow("RPC call failed", "error", err)
 	// Do not include any RPC specific data into the error as in CRE product it must be returned back to a workflow user
 	return pkgerrors.Wrap(err, "RPC call failed")

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -1412,14 +1412,30 @@ func (r *RPCClient) prepareCallArgs(msg ethereum.CallMsg) interface{} {
 	return toBackwardCompatibleCallArgWithChainTypeSupport(msg, r.chainType)
 }
 
+type sanitizedError struct {
+	err error
+	msg string
+}
+
+func (e sanitizedError) Error() string {
+	return e.msg
+}
+
+func (e sanitizedError) Unwrap() error {
+	return e.err
+}
+
 // Matches full HTTP(S)/WS(S) URLs so provider URLs, paths, query params, credentials, and API keys can be redacted from errors.
-var rpcURLRegexp = regexp.MustCompile(`(?:https?|wss?)://[^\s"']+/?`)
+var rpcURLRegexp = regexp.MustCompile(`(?i)(?:https?|wss?)://[^\s"']+`)
 
 func sanitizeRPCError(err error) error {
 	if err == nil {
 		return nil
 	}
-	return errors.New(rpcURLRegexp.ReplaceAllString(err.Error(), "[REDACTED URL]"))
+	return sanitizedError{
+		err: err,
+		msg: rpcURLRegexp.ReplaceAllString(err.Error(), "[REDACTED URL]"),
+	}
 }
 
 func (r *RPCClient) wrapRPCClientError(err error) error {
@@ -1427,7 +1443,10 @@ func (r *RPCClient) wrapRPCClientError(err error) error {
 		r.rpcLog.Trace("Call succeeded")
 		return nil
 	}
-	if pkgerrors.Cause(err).Error() == "context deadline exceeded" {
+	// Use errors.Is to walk the full Unwrap chain. A timeout surfaces as a *url.Error
+	// wrapping context.DeadlineExceeded; pkgerrors.Cause only follows the pkg/errors
+	// Cause() interface, which *url.Error does not implement, so it never matched.
+	if errors.Is(err, context.DeadlineExceeded) {
 		err = pkgerrors.Wrap(err, "remote node timed out")
 	}
 

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -1443,9 +1443,6 @@ func (r *RPCClient) wrapRPCClientError(err error) error {
 		r.rpcLog.Trace("Call succeeded")
 		return nil
 	}
-	// Use errors.Is to walk the full Unwrap chain. A timeout surfaces as a *url.Error
-	// wrapping context.DeadlineExceeded; pkgerrors.Cause only follows the pkg/errors
-	// Cause() interface, which *url.Error does not implement, so it never matched.
 	if errors.Is(err, context.DeadlineExceeded) {
 		err = pkgerrors.Wrap(err, "remote node timed out")
 	}

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -1412,7 +1412,7 @@ func (r *RPCClient) prepareCallArgs(msg ethereum.CallMsg) interface{} {
 	return toBackwardCompatibleCallArgWithChainTypeSupport(msg, r.chainType)
 }
 
-// Matches URLs and captures only the scheme + host, allowing path segments (e.g. API keys) to be stripped via replacement with "$1/".
+// Matches URLs to redact them and avoid leaking API keys
 var rpcURLRegexp = regexp.MustCompile(`https?://[^\s"']+`)
 
 func sanitizeRPCError(err error) error {

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -1412,8 +1412,8 @@ func (r *RPCClient) prepareCallArgs(msg ethereum.CallMsg) interface{} {
 	return toBackwardCompatibleCallArgWithChainTypeSupport(msg, r.chainType)
 }
 
-// Matches URLs to redact them and avoid leaking API keys
-var rpcURLRegexp = regexp.MustCompile(`https?://[^\s"']+`)
+// Matches full HTTP(S)/WS(S) URLs so provider URLs, paths, query params, credentials, and API keys can be redacted from errors.
+var rpcURLRegexp = regexp.MustCompile(`(?:https?|wss?)://[^\s"']+/?`)
 
 func sanitizeRPCError(err error) error {
 	if err == nil {

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -1413,13 +1413,13 @@ func (r *RPCClient) prepareCallArgs(msg ethereum.CallMsg) interface{} {
 }
 
 // Matches URLs and captures only the scheme + host, allowing path segments (e.g. API keys) to be stripped via replacement with "$1/".
-var rpcURLPathRegexp = regexp.MustCompile(`(https?://[^/\s"']+)/[^"'\s]*`)
+var rpcURLRegexp = regexp.MustCompile(`https?://[^\s"']+`)
 
 func sanitizeRPCError(err error) error {
 	if err == nil {
 		return nil
 	}
-	return errors.New(rpcURLPathRegexp.ReplaceAllString(err.Error(), "$1/"))
+	return errors.New(rpcURLRegexp.ReplaceAllString(err.Error(), "[REDACTED URL]"))
 }
 
 func (r *RPCClient) wrapRPCClientError(err error) error {

--- a/pkg/client/rpc_client.go
+++ b/pkg/client/rpc_client.go
@@ -1413,15 +1413,28 @@ func (r *RPCClient) prepareCallArgs(msg ethereum.CallMsg) interface{} {
 }
 
 type sanitizedError struct {
-	err error
-	msg string
+	err error  // original error, retained for chain traversal/classification
+	msg string // redacted, safe-to-display message
 }
 
 func (e sanitizedError) Error() string {
 	return e.msg
 }
 
+// Unwrap and Cause expose the original error so both the standard library
+// (errors.Is/errors.As) and pkg/errors (pkgerrors.Cause) can still traverse to
+// the underlying RPC error. This is required for error classification in
+// errors.go — e.g. ExtractRPCError marshals pkgerrors.Cause(err) into a
+// JsonError, and isFatalSendError matches against pkgerrors.Cause(err).Error() —
+// and for sentinel matching such as ethereum.NotFound and context.DeadlineExceeded.
+//
+// Only the Error() string is redacted. That is the value logged and returned to
+// workflow users, which is where the provider URL/API key was leaking.
 func (e sanitizedError) Unwrap() error {
+	return e.err
+}
+
+func (e sanitizedError) Cause() error {
 	return e.err
 }
 

--- a/pkg/client/rpc_client_internal_test.go
+++ b/pkg/client/rpc_client_internal_test.go
@@ -39,43 +39,45 @@ func TestSanitizeRPCError(t *testing.T) {
 	}{
 		{
 			name: "https url with path",
-			err:  errors.New(`Post "https://test-cl-03.test.xyz/dOnOtLeAkAnyOfThis/doNotLeak/test/mainnet/": context deadline exceeded`),
+			err:  fmt.Errorf(`Post "https://test-cl-03.test.xyz/dOnOtLeAkAnyOfThis/doNotLeak/test/mainnet/": %w`, context.DeadlineExceeded),
 			want: `Post "[REDACTED URL]": context deadline exceeded`,
 		},
 		{
 			name: "http url with path",
-			err:  errors.New(`Post "http://secret.com/doNotLeak/": context deadline exceeded`),
+			err:  fmt.Errorf(`Post "http://secret.com/doNotLeak/": %w`, context.DeadlineExceeded),
 			want: `Post "[REDACTED URL]": context deadline exceeded`,
 		},
 		{
 			name: "ws url with path",
-			err:  errors.New(`dial "ws://secret.com/doNotLeak/": context deadline exceeded`),
+			err:  fmt.Errorf(`dial "ws://secret.com/doNotLeak/": %w`, context.DeadlineExceeded),
 			want: `dial "[REDACTED URL]": context deadline exceeded`,
 		},
 		{
 			name: "wss url with path",
-			err:  errors.New(`dial "wss://secret.com/doNotLeak/": context deadline exceeded`),
+			err:  fmt.Errorf(`dial "wss://secret.com/doNotLeak/": %w`, context.DeadlineExceeded),
 			want: `dial "[REDACTED URL]": context deadline exceeded`,
 		},
 		{
 			name: "https url with user info",
-			err:  errors.New(`Post "https://user:pass@secret.com/": context deadline exceeded`),
+			err:  fmt.Errorf(`Post "https://user:pass@secret.com/": %w`, context.DeadlineExceeded),
 			want: `Post "[REDACTED URL]": context deadline exceeded`,
 		},
 		{
 			name: "multiple urls",
-			err:  errors.New(`primary http://secret.com/doNotLeak/ fallback wss://secret.com/doNotLeak/ failed`),
-			want: `primary [REDACTED URL] fallback [REDACTED URL] failed`,
+			err:  fmt.Errorf(`primary http://secret.com/doNotLeak/ fallback wss://secret.com/doNotLeak/ failed: %w`, context.DeadlineExceeded),
+			want: `primary [REDACTED URL] fallback [REDACTED URL] failed: context deadline exceeded`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sanitized := sanitizeRPCError(tt.err)
+
 			require.EqualError(t, sanitized, tt.want)
 			require.NotContains(t, sanitized.Error(), "doNotLeak")
 			require.NotContains(t, sanitized.Error(), "user:pass")
 			require.NotContains(t, sanitized.Error(), "secret.com")
+			require.ErrorIs(t, sanitized, context.DeadlineExceeded)
 		})
 	}
 }
@@ -99,6 +101,12 @@ func TestRPCClient_WrapRPCClientError_TimeoutIsWrappedAndSanitized(t *testing.T)
 	require.NotContains(t, wrapped.Error(), "user:pass")
 	require.NotContains(t, wrapped.Error(), "test-cl-03.test.xyz")
 	require.NotContains(t, wrapped.Error(), "dOnOtLeAkAnyOfThis")
+
+	// The timeout must be detected through the *url.Error -> context.DeadlineExceeded
+	// chain and surfaced as "remote node timed out".
+	require.ErrorContains(t, wrapped, "remote node timed out")
+	// The error type must be preserved so callers can still match the timeout.
+	require.ErrorIs(t, wrapped, context.DeadlineExceeded)
 }
 
 func TestRPCClient_MakeLogsValid(t *testing.T) {

--- a/pkg/client/rpc_client_internal_test.go
+++ b/pkg/client/rpc_client_internal_test.go
@@ -32,13 +32,52 @@ import (
 func TestSanitizeRPCError(t *testing.T) {
 	t.Parallel()
 
-	err := errors.New(`Post "https://test-cl-03.test.xyz/dOnOtLeAkAnyOfThis/doNotLeak/test/mainnet/": context deadline exceeded`)
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "https url with path",
+			err:  errors.New(`Post "https://test-cl-03.test.xyz/dOnOtLeAkAnyOfThis/doNotLeak/test/mainnet/": context deadline exceeded`),
+			want: `Post "[REDACTED URL]": context deadline exceeded`,
+		},
+		{
+			name: "http url with path",
+			err:  errors.New(`Post "http://secret.com/doNotLeak/": context deadline exceeded`),
+			want: `Post "[REDACTED URL]": context deadline exceeded`,
+		},
+		{
+			name: "ws url with path",
+			err:  errors.New(`dial "ws://secret.com/doNotLeak/": context deadline exceeded`),
+			want: `dial "[REDACTED URL]": context deadline exceeded`,
+		},
+		{
+			name: "wss url with path",
+			err:  errors.New(`dial "wss://secret.com/doNotLeak/": context deadline exceeded`),
+			want: `dial "[REDACTED URL]": context deadline exceeded`,
+		},
+		{
+			name: "https url with user info",
+			err:  errors.New(`Post "https://user:pass@secret.com/": context deadline exceeded`),
+			want: `Post "[REDACTED URL]": context deadline exceeded`,
+		},
+		{
+			name: "multiple urls",
+			err:  errors.New(`primary http://secret.com/doNotLeak/ fallback wss://secret.com/doNotLeak/ failed`),
+			want: `primary [REDACTED URL] fallback [REDACTED URL] failed`,
+		},
+	}
 
-	sanitized := sanitizeRPCError(err)
-
-	require.EqualError(t, sanitized,
-		`Post "[REDACTED URL]": context deadline exceeded`,
-	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sanitized := sanitizeRPCError(tt.err)
+			require.EqualError(t, sanitized, tt.want)
+			require.NotContains(t, sanitized.Error(), "doNotLeak")
+			require.NotContains(t, sanitized.Error(), "user:pass")
+			require.NotContains(t, sanitized.Error(), "secret.com")
+		})
+	}
 }
 
 func TestRPCClient_WrapRPCClientError_TimeoutIsWrappedAndSanitized(t *testing.T) {
@@ -48,7 +87,7 @@ func TestRPCClient_WrapRPCClientError_TimeoutIsWrappedAndSanitized(t *testing.T)
 
 	err := &url.Error{
 		Op:  "Post",
-		URL: "https://test-cl-03.test.xyz/dOnOtLeAkAnyOfThis/doNotLeak/test/mainnet/",
+		URL: "https://user:pass@test-cl-03.test.xyz/dOnOtLeAkAnyOfThis/doNotLeak/test/mainnet/",
 		Err: context.DeadlineExceeded,
 	}
 
@@ -56,7 +95,9 @@ func TestRPCClient_WrapRPCClientError_TimeoutIsWrappedAndSanitized(t *testing.T)
 
 	require.ErrorContains(t, wrapped, "RPC call failed")
 	require.ErrorContains(t, wrapped, "[REDACTED URL]")
-	require.NotContains(t, wrapped.Error(), "https://test-cl-03.test.xyz")
+	require.NotContains(t, wrapped.Error(), "https://")
+	require.NotContains(t, wrapped.Error(), "user:pass")
+	require.NotContains(t, wrapped.Error(), "test-cl-03.test.xyz")
 	require.NotContains(t, wrapped.Error(), "dOnOtLeAkAnyOfThis")
 }
 

--- a/pkg/client/rpc_client_internal_test.go
+++ b/pkg/client/rpc_client_internal_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -27,6 +28,36 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
 	evmtypes "github.com/smartcontractkit/chainlink-evm/pkg/types"
 )
+
+func TestSanitizeRPCError(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New(`Post "https://test-cl-03.test.xyz/dOnOtLeAkAnyOfThis/doNotLeak/test/mainnet/": context deadline exceeded`)
+
+	sanitized := sanitizeRPCError(err)
+
+	require.EqualError(t, sanitized,
+		`Post "https://test-cl-03.test.xyz/": context deadline exceeded`,
+	)
+}
+
+func TestRPCClient_WrapRPCClientError_TimeoutIsWrappedAndSanitized(t *testing.T) {
+	t.Parallel()
+
+	rpcClient := NewTestRPCClient(t, RPCClientOpts{})
+
+	err := &url.Error{
+		Op:  "Post",
+		URL: "https://test-cl-03.test.xyz/dOnOtLeAkAnyOfThis/doNotLeak/test/mainnet/",
+		Err: context.DeadlineExceeded,
+	}
+
+	wrapped := rpcClient.wrapRPCClientError(err)
+
+	require.ErrorContains(t, wrapped, "RPC call failed")
+	require.ErrorContains(t, wrapped, `https://test-cl-03.test.xyz/`)
+	require.NotContains(t, wrapped.Error(), "dOnOtLeAkAnyOfThis")
+}
 
 func TestRPCClient_MakeLogsValid(t *testing.T) {
 	chainTypes := []struct {

--- a/pkg/client/rpc_client_internal_test.go
+++ b/pkg/client/rpc_client_internal_test.go
@@ -37,7 +37,7 @@ func TestSanitizeRPCError(t *testing.T) {
 	sanitized := sanitizeRPCError(err)
 
 	require.EqualError(t, sanitized,
-		`Post "https://test-cl-03.test.xyz/": context deadline exceeded`,
+		`Post "[REDACTED URL]": context deadline exceeded`,
 	)
 }
 
@@ -55,7 +55,8 @@ func TestRPCClient_WrapRPCClientError_TimeoutIsWrappedAndSanitized(t *testing.T)
 	wrapped := rpcClient.wrapRPCClientError(err)
 
 	require.ErrorContains(t, wrapped, "RPC call failed")
-	require.ErrorContains(t, wrapped, `https://test-cl-03.test.xyz/`)
+	require.ErrorContains(t, wrapped, "[REDACTED URL]")
+	require.NotContains(t, wrapped.Error(), "https://test-cl-03.test.xyz")
 	require.NotContains(t, wrapped.Error(), "dOnOtLeAkAnyOfThis")
 }
 


### PR DESCRIPTION
Remove URLs from rpc errors to avoid leaking API keys.