### PR TITLE
fix(txmgr): validate Scroll stuck-tx API response hashes

### DIFF
--- a/pkg/txmgr/attempts.go
+++ b/pkg/txmgr/attempts.go
@@ -87,7 +87,10 @@ func (c *evmTxAttemptBuilder) NewBumpTxAttempt(ctx context.Context, etx Tx, prev
 func (c *evmTxAttemptBuilder) NewPurgeTxAttempt(ctx context.Context, etx Tx, lggr logger.Logger) (attempt TxAttempt, err error) {
 	// Use the LimitDefault since this is an empty tx
 	gasLimit := c.feeConfig.LimitDefault()
-	// Transactions being purged will always have a previous attempt since it had to have been broadcasted before at least once
+	if len(etx.TxAttempts) == 0 {
+		return attempt, fmt.Errorf("cannot purge tx %d: no previous attempts", etx.ID)
+	}
+	// Use the first previous attempt to derive the purge attempt's bumped fee and tx type.
 	previousAttempt := etx.TxAttempts[0]
 	keySpecificMaxGasPriceWei := c.feeConfig.PriceMaxKey(etx.FromAddress)
 	bumpedFee, _, err := c.EvmFeeEstimator.BumpFee(ctx, previousAttempt.TxFee, etx.FeeLimit, keySpecificMaxGasPriceWei, newEvmPriorAttempts(etx.TxAttempts))

--- a/pkg/txmgr/attempts_test.go
+++ b/pkg/txmgr/attempts_test.go
@@ -226,6 +226,13 @@ func TestTxm_NewPurgeAttempt(t *testing.T) {
 	cks := txmgr.NewEvmTxAttemptBuilder(*big.NewInt(1), gc, kst, est)
 	lggr := logger.Test(t)
 
+	t.Run("returns error when tx has no attempts", func(t *testing.T) {
+		etx := txmgr.Tx{ID: 42}
+		_, err := cks.NewPurgeTxAttempt(t.Context(), etx, lggr)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot purge tx 42: no previous attempts")
+	})
+
 	t.Run("creates legacy purge attempt with fields if previous attempt is legacy", func(t *testing.T) {
 		n := evmtypes.Nonce(0)
 		etx := txmgr.Tx{Sequence: &n, FromAddress: addr, EncodedPayload: []byte{1, 2, 3}}

--- a/pkg/txmgr/stuck_tx_detector.go
+++ b/pkg/txmgr/stuck_tx_detector.go
@@ -352,9 +352,15 @@ func (d *stuckTxDetector) detectStuckTransactionsScroll(ctx context.Context, txs
 	// Return all transactions marked with status 1 signaling they have been skipped due to overflow
 	var stuckTx []Tx
 	for hash, status := range scrollResp.Data {
-		if status == 1 {
-			stuckTx = append(stuckTx, attemptHashMap[hash])
+		if status != 1 {
+			continue
 		}
+		tx, ok := attemptHashMap[hash]
+		if !ok {
+			d.lggr.Warnw("scroll stuck tx API returned unknown hash", "hash", hash)
+			continue
+		}
+		stuckTx = append(stuckTx, tx)
 	}
 
 	return stuckTx, nil

--- a/pkg/txmgr/stuck_tx_detector_test.go
+++ b/pkg/txmgr/stuck_tx_detector_test.go
@@ -521,6 +521,30 @@ func TestStuckTxDetector_DetectStuckTransactionsScroll(t *testing.T) {
 		require.Len(t, txs, 1)
 		require.Equal(t, tx1.ID, txs[0].ID)
 	})
+
+	t.Run("ignores unknown hashes returned by the scroll API", func(t *testing.T) {
+		fromAddress := testutils.NewAddress()
+		tx1 := mustInsertUnconfirmedTxWithBroadcastAttempts(t, txStore, 0, fromAddress, 1, blockNum, tenGwei)
+		attempts1 := tx1.TxAttempts[0]
+
+		testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			_, _ = fmt.Fprintf(res, `{"errcode": 0,"errmsg": "","data": {"%s": 1, "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef": 1}}`, attempts1.Hash)
+		}))
+		defer func() { testServer.Close() }()
+		testURL, err := url.Parse(testServer.URL)
+		require.NoError(t, err)
+
+		autoPurgeCfg := testAutoPurgeConfig{
+			enabled:         true,
+			detectionApiUrl: testURL,
+		}
+		stuckTxDetector := txmgr.NewStuckTxDetector(lggr, testutils.FixtureChainID, chaintype.ChainScroll, assets.NewWei(assets.NewEth(100).ToInt()), autoPurgeCfg, feeEstimator, txStore, ethClient)
+
+		txs, err := stuckTxDetector.DetectStuckTransactions(ctx, []common.Address{fromAddress}, blockNum)
+		require.NoError(t, err)
+		require.Len(t, txs, 1)
+		require.Equal(t, tx1.ID, txs[0].ID)
+	})
 }
 
 func mustInsertUnconfirmedTxWithBroadcastAttempts(t testing.TB, txStore txmgr.TestEvmTxStore, nonce int64, fromAddress common.Address, numAttempts uint32, latestBroadcastBlockNum int64, latestGasPrice *assets.Wei) txmgr.Tx {


### PR DESCRIPTION
Ignore unknown hashes returned by sequencer API instead of appending zero-value transactions that panic in NewPurgeTxAttempt.