### PR TITLE
fix: guard against empty baseFeePerGas in FeeHistoryEstimator.RefreshDynamicPrice

### DIFF
--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -237,6 +237,14 @@ func (f *FeeHistoryEstimator) RefreshDynamicPrice() error {
 		return err
 	}
 
+	// Some RPC providers return a 200/success response with an empty (or short) BaseFee
+	// array instead of an error, e.g. when a deep/archive range can't be served or the
+	// upstream doesn't fully support eth_feeHistory. Treat that the same as an RPC error
+	// instead of indexing into an empty slice below.
+	if len(feeHistory.BaseFee) == 0 {
+		return fmt.Errorf("eth_feeHistory returned an empty baseFeePerGas array for chain %s", f.chainID.String())
+	}
+
 	// eth_feeHistory doesn't return the latest baseFee of the range but rather the latest + 1, because it can be derived from the existing
 	// values. Source: https://github.com/ethereum/go-ethereum/blob/b0f66e34ca2a4ea7ae23475224451c8c9a569826/eth/gasprice/feehistory.go#L235
 	// nextBlock is the latest returned + 1 to be aligned with the base fee value.

--- a/pkg/gas/fee_history_estimator_empty_basefee_test.go
+++ b/pkg/gas/fee_history_estimator_empty_basefee_test.go
@@ -1,0 +1,44 @@
+package gas_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
+	"github.com/smartcontractkit/chainlink-evm/pkg/gas/mocks"
+	"github.com/smartcontractkit/chainlink-evm/pkg/testutils"
+)
+
+// TestRefreshDynamicPrice_EmptyBaseFee is a regression test for a production
+// crash: FeeHistoryEstimator.RefreshDynamicPrice panicked with
+// "index out of range [-1]" whenever the upstream eth_feeHistory response had
+// an empty BaseFee ([]) array. Real RPC providers do return this shape (e.g.
+// on a deep/archive range some providers can't serve, or on chains without
+// full EIP-1559 support), and it reached this code path unmodified from the
+// underlying client — no error, just an empty slice.
+func TestRefreshDynamicPrice_EmptyBaseFee(t *testing.T) {
+	client := mocks.NewFeeHistoryEstimatorClient(t)
+	chainID := testutils.FixtureChainID
+
+	feeHistoryResult := &ethereum.FeeHistory{
+		OldestBlock:  big.NewInt(100),
+		Reward:       [][]*big.Int{{big.NewInt(1), big.NewInt(2)}},
+		BaseFee:      []*big.Int{}, // reproduction: empty BaseFee array, err == nil
+		GasUsedRatio: nil,
+	}
+	client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+
+	cfg := gas.FeeHistoryEstimatorConfig{BlockHistorySize: 2, RewardPercentile: 60}
+	u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
+
+	assert.NotPanics(t, func() {
+		err := u.RefreshDynamicPrice()
+		assert.ErrorContains(t, err, "empty baseFeePerGas array")
+	})
+}


### PR DESCRIPTION
## Summary

`FeeHistoryEstimator.RefreshDynamicPrice` indexes into `feeHistory.BaseFee` with
`feeHistory.BaseFee[len(feeHistory.BaseFee)-1]` without checking the slice is
non-empty. If an `eth_feeHistory` RPC call returns `err == nil` with an empty
`baseFeePerGas` array — which we've observed real providers do instead of
returning an error, e.g. on a deep/archive block range they can't serve, or on
chains without full EIP-1559 support — this indexes with `-1` and panics:

```
panic: runtime error: index out of range [-1]

goroutine ... [running]:
github.com/smartcontractkit/chainlink-evm/pkg/gas.(*FeeHistoryEstimator).RefreshDynamicPrice(...)
	pkg/gas/fee_history_estimator.go:243 +0x8e5
github.com/smartcontractkit/chainlink-evm/pkg/gas.(*FeeHistoryEstimator).run(...)
	pkg/gas/fee_history_estimator.go:130 +0x105
```

Because `RefreshDynamicPrice` runs in an unrecovered background goroutine
(`FeeHistoryEstimator.run`), this panic is fatal to the entire node process —
not just the affected chain's gas estimator. Every chain and job the node
services goes down until the process is restarted.

Note the `Reward` slice a few lines below this is already defended
(`if len(reward) < 2 { continue }`); `BaseFee` was not.

## Impact observed

We hit this in production across three separate CCIP node deployments running
different chainlink-evm builds (pseudo-versions from Feb, Mar, and Jun 2026),
on different physical hosts, recurring in bursts over several weeks before we
root-caused it. Log history shows it's been reachable since at least the
February 2026 build.

## Fix

Added a bounds check right after the existing RPC-error check, returning a
descriptive error instead of indexing into the empty slice — the same
treatment already given to a malformed `Reward` response a few lines down.

## Testing

Added `TestRefreshDynamicPrice_EmptyBaseFee`, which reproduces the panic
against the real package using its own mocks (feeding an empty `BaseFee` with
`err == nil`) and confirms the fix returns a graceful error instead. Full
existing `pkg/gas` test suite passes unmodified; `go vet` is clean.