### PR TITLE
LP Skip Blocks

### DIFF
--- a/pkg/logpoller/disabled.go
+++ b/pkg/logpoller/disabled.go
@@ -129,3 +129,7 @@ func (d disabled) FindLCA(ctx context.Context) (*Block, error) {
 func (d disabled) DeleteLogsAndBlocksAfter(ctx context.Context, start int64) error {
 	return ErrDisabled
 }
+
+func (d disabled) SkipToBlock(ctx context.Context, blockNumber int64) error {
+	return ErrDisabled
+}

--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/timeutil"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mathutil"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/client"
@@ -55,6 +56,10 @@ type LogPoller interface {
 	GetBlocksRange(ctx context.Context, numbers []uint64) ([]Block, error)
 	FindLCA(ctx context.Context) (*Block, error)
 	DeleteLogsAndBlocksAfter(ctx context.Context, start int64) error
+	// SkipToBlock repositions the poller to start processing from blockNumber (T).
+	// Block T-1 is fetched from RPC and saved as the anchor; the next poll resumes from T.
+	// Returns an error if T-1 is not finalized on chain.
+	SkipToBlock(ctx context.Context, blockNumber int64) error
 
 	// General querying
 	Logs(ctx context.Context, start, end int64, eventSig common.Hash, address common.Address) ([]Log, error)
@@ -91,6 +96,7 @@ type LogPollerTest interface {
 
 type Client interface {
 	HeadByNumber(ctx context.Context, n *big.Int) (*evmtypes.Head, error)
+	HeaderByNumberWithOpts(ctx context.Context, number *big.Int, opts evmtypes.HeaderByNumberOpts) (*evmtypes.Header, error)
 	HeadByHash(ctx context.Context, n common.Hash) (*evmtypes.Head, error)
 	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
@@ -1870,15 +1876,7 @@ func (lp *logPoller) batchFetchBlocks(ctx context.Context, blocksRequested []uin
 		}
 
 		for _, head := range fetched1 {
-			lpBlock := Block{
-				EVMChainID:           head.EVMChainID,
-				BlockHash:            head.Hash,
-				BlockNumber:          head.Number,
-				BlockTimestamp:       head.Timestamp,
-				FinalizedBlockNumber: head.Number, // always finalized; only matters if this block is returned by LatestBlock()
-				SafeBlockNumber:      head.Number,
-				CreatedAt:            head.CreatedAt,
-			}
+			lpBlock := finalizedHeadToBlock(head)
 			logPollerBlocks[uint64(head.Number)] = lpBlock //nolint:gosec // G115
 			if chainValidationHead == nil || chainValidationHead.BlockNumber < lpBlock.BlockNumber {
 				chainValidationHead = &lpBlock
@@ -1887,6 +1885,18 @@ func (lp *logPoller) batchFetchBlocks(ctx context.Context, blocksRequested []uin
 	}
 
 	return logPollerBlocks, nil
+}
+
+func finalizedHeadToBlock(head *evmtypes.Head) Block {
+	return Block{
+		EVMChainID:           head.EVMChainID,
+		BlockHash:            head.Hash,
+		BlockNumber:          head.Number,
+		BlockTimestamp:       head.Timestamp,
+		FinalizedBlockNumber: head.Number, // always finalized; only matters if this block is returned by LatestBlock()
+		SafeBlockNumber:      head.Number,
+		CreatedAt:            head.CreatedAt,
+	}
 }
 
 func ensureIdenticalBlocksBatches(fetched1, fetched2 map[uint64]*evmtypes.Head) error {
@@ -1918,16 +1928,27 @@ func validateBlockResponse(r rpc.BatchElem) (*evmtypes.Head, error) {
 	if !is {
 		return nil, pkgerrors.Errorf("expected result to be a %T, got %T", &evmtypes.Head{}, r.Result)
 	}
+
+	err := validateHead(block)
+	if err != nil {
+		return nil, err
+	}
+
+	return block, nil
+}
+
+func validateHead(block *evmtypes.Head) error {
 	if block == nil {
-		return nil, pkgerrors.New("invariant violation: got nil block")
+		return pkgerrors.New("invariant violation: got nil block")
 	}
 	if block.Hash == (common.Hash{}) {
-		return nil, pkgerrors.Errorf("missing block hash for block number: %d", block.Number)
+		return pkgerrors.Errorf("missing block hash for block number: %d", block.Number)
 	}
 	if block.Number < 0 {
-		return nil, pkgerrors.Errorf("expected block number to be >= to 0, got %d", block.Number)
+		return pkgerrors.Errorf("expected block number to be >= to 0, got %d", block.Number)
 	}
-	return block, nil
+
+	return nil
 }
 
 // IndexedLogsWithSigsExcluding returns the set difference(A-B) of logs with signature sigA and sigB, matching is done on the topics index
@@ -1941,6 +1962,51 @@ func (lp *logPoller) IndexedLogsWithSigsExcluding(ctx context.Context, address c
 // DeleteLogsAndBlocksAfter - removes blocks and logs starting from the specified block
 func (lp *logPoller) DeleteLogsAndBlocksAfter(ctx context.Context, start int64) error {
 	return lp.orm.DeleteLogsAndBlocksAfter(ctx, start)
+}
+
+// SkipToBlock repositions the poller to start processing from blockNumber (T).
+// Block T-1 is fetched from RPC and saved as the anchor; the next poll resumes from T.
+// Returns an error if T-1 is not finalized on chain.
+func (lp *logPoller) SkipToBlock(ctx context.Context, blockNumber int64) error {
+	if blockNumber < 2 {
+		return fmt.Errorf("invalid skip block number %d, must be >= 2", blockNumber)
+	}
+
+	lp.runMu.Lock()
+	defer lp.runMu.Unlock()
+
+	anchorBlockNumber := blockNumber - 1
+
+	anchorHead, err := lp.ec.HeaderByNumberWithOpts(ctx, big.NewInt(anchorBlockNumber), evmtypes.HeaderByNumberOpts{ConfidenceLevel: primitives.Finalized})
+	if err != nil {
+		return fmt.Errorf("failed to fetch anchor block %d from RPC: %w", anchorBlockNumber, err)
+	}
+
+	err = validateHead((*evmtypes.Head)(anchorHead))
+	if err != nil {
+		return fmt.Errorf("failed to validate anchor block %d: %w", anchorBlockNumber, err)
+	}
+
+	anchorBlock := finalizedHeadToBlock((*evmtypes.Head)(anchorHead))
+
+	latest, err := lp.orm.SelectLatestBlock(ctx)
+	if err != nil && !pkgerrors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("failed to select latest block: %w", err)
+	}
+
+	minBlockToPrune := anchorBlockNumber
+	if latest != nil && latest.FinalizedBlockNumber < minBlockToPrune {
+		minBlockToPrune = latest.FinalizedBlockNumber + 1
+	}
+
+	err = lp.orm.StoreNewFinalizedCheckpoint(ctx, anchorBlock, minBlockToPrune)
+	if err != nil {
+		return fmt.Errorf("failed to store new finalized checkpoint: %w", err)
+	}
+	lp.backupPollerNextBlock = anchorBlockNumber
+
+	lp.lggr.Infof("Skipped to block %d. Next poll starts at %d", anchorBlockNumber, blockNumber)
+	return nil
 }
 
 func (lp *logPoller) FindLCA(ctx context.Context) (*Block, error) {

--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -136,11 +136,17 @@ type logPoller struct {
 	filterDirty     bool
 	cachedAddresses []common.Address
 	cachedEventSigs []common.Hash
+	filtersLoaded   bool
 
 	replayStart    chan int64
 	replayComplete chan error
 	stopCh         services.StopChan
 	wg             sync.WaitGroup
+	// ensures that jobs outside main loop do not run concurrently with it.
+	// Mainly needed to simplify mental model and exclude concurrent changes to the blocks table, while handling reorgs.
+	// Pruning of old blocks is intentionally excluded from this lock, because they are much older
+	// than a block range that could be affected by a reorg.
+	runMu sync.Mutex
 	// This flag is raised whenever the log poller detects that the chain's finality has been violated.
 	// It can happen when reorg is deeper than the latest finalized block that LogPoller saw in a previous PollAndSave tick.
 	// Usually the only way to recover is to manually remove the offending logs and block from the database.
@@ -675,72 +681,82 @@ func (lp *logPoller) run() {
 		lp.lggr.Infow("Backup log poller disabled")
 	}
 
-	filtersLoaded := false
-
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case fromBlockReq := <-lp.replayStart:
-			lp.handleReplayRequest(ctx, fromBlockReq, filtersLoaded)
+			lp.handleReplayRequest(ctx, fromBlockReq)
 		case <-logPollTicker.C:
-			if !filtersLoaded {
-				if err := lp.loadFilters(ctx); err != nil {
-					lp.lggr.Errorw("Failed loading filters in main logpoller loop, retrying later", "err", err)
-					continue
-				}
-				filtersLoaded = true
-			}
-
-			// Always start from the latest block in the db.
-			var start int64
-			lastProcessed, err := lp.orm.SelectLatestBlock(ctx)
-			if err != nil {
-				if !pkgerrors.Is(err, sql.ErrNoRows) {
-					// Assume transient db reading issue, retry forever.
-					lp.lggr.Errorw("unable to get starting block", "err", err)
-					continue
-				}
-				// Otherwise this is the first poll _ever_ on a new chain.
-				// Only safe thing to do is to start at the first finalized block.
-				_, latestFinalizedBlockNumber, err := lp.latestAndFinalizedBlocks(ctx)
-				if err != nil {
-					lp.lggr.Warnw("Unable to get latest for first poll", "err", err)
-					continue
-				}
-				// Starting at the first finalized block. We do not backfill the first finalized block.
-				start = latestFinalizedBlockNumber
-			} else {
-				lp.metrics.RecordLastProcessedBlock(ctx, lastProcessed.BlockNumber)
-				start = lastProcessed.BlockNumber + 1
-			}
-			lp.PollAndSaveLogs(ctx, start, false)
+			lp.tickPoll(ctx)
 		case <-backupLogPollCh:
-			// Backup log poller:  this serves as an emergency backup to protect against eventual-consistency behavior
-			// of an rpc node (seen occasionally on optimism, but possibly could happen on other chains?).  If the first
-			// time we request a block, no logs or incomplete logs come back, this ensures that every log is eventually
-			// re-requested after it is finalized. This doesn't add much overhead, because we can request all of them
-			// in one shot, since we don't need to worry about re-orgs after finality depth, and it runs far less
-			// frequently than the primary log poller (instead of roughly once per block it runs once roughly once every
-			// lp.backupPollerDelay blocks--with default settings about 100x less frequently).
-
-			if !filtersLoaded {
-				lp.lggr.Warnw("Backup log poller ran before filters loaded, skipping")
-				continue
-			}
-			err := lp.BackupPollAndSaveLogs(ctx)
-			switch {
-			case errors.Is(err, commontypes.ErrFinalityViolated):
-				// BackupPoll only declares finality violation and does not resolve it, as it's possible that processed range
-				// does not contain the violation.
-				lp.lggr.Criticalw("Backup poll failed due to finality violation", "err", err)
-				lp.finalityViolated.Store(true)
-				lp.SvcErrBuffer.Append(err)
-			case err != nil:
-				lp.lggr.Errorw("Backup poller failed, retrying later", "err", err)
-			}
+			lp.tickBackupPoll(ctx)
 		}
 	}
+}
+
+func (lp *logPoller) tickBackupPoll(ctx context.Context) {
+	lp.runMu.Lock()
+	defer lp.runMu.Unlock()
+	// Backup log poller:  this serves as an emergency backup to protect against eventual-consistency behavior
+	// of an rpc node (seen occasionally on optimism, but possibly could happen on other chains?).  If the first
+	// time we request a block, no logs or incomplete logs come back, this ensures that every log is eventually
+	// re-requested after it is finalized. This doesn't add much overhead, because we can request all of them
+	// in one shot, since we don't need to worry about re-orgs after finality depth, and it runs far less
+	// frequently than the primary log poller (instead of roughly once per block it runs once roughly once every
+	// lp.backupPollerDelay blocks--with default settings about 100x less frequently).
+
+	if !lp.filtersLoaded {
+		lp.lggr.Warnw("Backup log poller ran before filters loaded, skipping")
+		return
+	}
+	err := lp.BackupPollAndSaveLogs(ctx)
+	switch {
+	case errors.Is(err, commontypes.ErrFinalityViolated):
+		// BackupPoll only declares finality violation and does not resolve it, as it's possible that processed range
+		// does not contain the violation.
+		lp.lggr.Criticalw("Backup poll failed due to finality violation", "err", err)
+		lp.finalityViolated.Store(true)
+		lp.SvcErrBuffer.Append(err)
+	case err != nil:
+		lp.lggr.Errorw("Backup poller failed, retrying later", "err", err)
+	}
+}
+
+func (lp *logPoller) tickPoll(ctx context.Context) {
+	lp.runMu.Lock()
+	defer lp.runMu.Unlock()
+	if !lp.filtersLoaded {
+		if err := lp.loadFilters(ctx); err != nil {
+			lp.lggr.Errorw("Failed loading filters in main logpoller loop, retrying later", "err", err)
+			return
+		}
+		lp.filtersLoaded = true
+	}
+
+	// Always start from the latest block in the db.
+	var start int64
+	lastProcessed, err := lp.orm.SelectLatestBlock(ctx)
+	if err != nil {
+		if !pkgerrors.Is(err, sql.ErrNoRows) {
+			// Assume transient db reading issue, retry forever.
+			lp.lggr.Errorw("unable to get starting block", "err", err)
+			return
+		}
+		// Otherwise this is the first poll _ever_ on a new chain.
+		// Only safe thing to do is to start at the first finalized block.
+		_, latestFinalizedBlockNumber, err := lp.latestAndFinalizedBlocks(ctx)
+		if err != nil {
+			lp.lggr.Warnw("Unable to get latest for first poll", "err", err)
+			return
+		}
+		// Starting at the first finalized block. We do not backfill the first finalized block.
+		start = latestFinalizedBlockNumber
+	} else {
+		lp.metrics.RecordLastProcessedBlock(ctx, lastProcessed.BlockNumber)
+		start = lastProcessed.BlockNumber + 1
+	}
+	lp.PollAndSaveLogs(ctx, start, false)
 }
 
 func (lp *logPoller) backgroundWorkerRun() {
@@ -809,13 +825,17 @@ func (lp *logPoller) backgroundWorkerRun() {
 	}
 }
 
-func (lp *logPoller) handleReplayRequest(ctx context.Context, fromBlockReq int64, filtersLoaded bool) {
+func (lp *logPoller) handleReplayRequest(ctx context.Context, fromBlockReq int64) {
+	lp.runMu.Lock()
+	defer lp.runMu.Unlock()
 	fromBlock, err := lp.GetReplayFromBlock(ctx, fromBlockReq)
 	if err == nil {
-		if !filtersLoaded {
+		if !lp.filtersLoaded {
 			lp.lggr.Warnw("Received replayReq before filters loaded", "fromBlock", fromBlock, "requested", fromBlockReq)
 			if err = lp.loadFilters(ctx); err != nil {
 				lp.lggr.Errorw("Failed loading filters during Replay", "err", err, "fromBlock", fromBlock)
+			} else {
+				lp.filtersLoaded = true
 			}
 		}
 		if err == nil {

--- a/pkg/logpoller/log_poller_internal_test.go
+++ b/pkg/logpoller/log_poller_internal_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	"github.com/smartcontractkit/chainlink-evm/pkg/client/clienttest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/heads/headstest"
 	"github.com/smartcontractkit/chainlink-evm/pkg/logpoller/internal/log_emitter"
@@ -2146,4 +2147,152 @@ func BenchmarkFilter100_10(b *testing.B) {
 }
 func BenchmarkFilter1000_100(b *testing.B) {
 	benchmarkFilter(b, 1000, 100, 100)
+}
+
+func skipToBlockOpts() Opts {
+	return Opts{
+		UseFinalityTag:           false,
+		FinalityDepth:            2,
+		BackfillBatchSize:        3,
+		RPCBatchSize:             2,
+		KeepFinalizedBlocksDepth: 1000,
+		PollPeriod:               time.Hour,
+	}
+}
+
+func expectFinalizedAnchorHeader(t *testing.T, ec *clienttest.Client, anchorBlockNumber int64) {
+	t.Helper()
+	ec.EXPECT().HeaderByNumberWithOpts(
+		mock.Anything,
+		big.NewInt(anchorBlockNumber),
+		evmtypes.HeaderByNumberOpts{ConfidenceLevel: primitives.Finalized},
+	).RunAndReturn(func(_ context.Context, _ *big.Int, _ evmtypes.HeaderByNumberOpts) (*evmtypes.Header, error) {
+		head := newHeadVal(anchorBlockNumber)
+		hdr := evmtypes.Header(head)
+		return &hdr, nil
+	}).Once()
+}
+
+func expectStoreNewFinalizedCheckpoint(t *testing.T, orm *MockORM, anchorBlockNumber, minBlockToPrune int64) {
+	t.Helper()
+	orm.EXPECT().StoreNewFinalizedCheckpoint(
+		mock.Anything,
+		mock.MatchedBy(func(b Block) bool {
+			return b.BlockNumber == anchorBlockNumber &&
+				b.BlockHash == hashOf(anchorBlockNumber) &&
+				b.FinalizedBlockNumber == anchorBlockNumber &&
+				b.SafeBlockNumber == anchorBlockNumber
+		}),
+		minBlockToPrune,
+	).Return(nil).Once()
+}
+
+func Test_skipToBlock(t *testing.T) {
+	t.Parallel()
+	ctx := testutils.Context(t)
+
+	t.Run("invalid block number", func(t *testing.T) {
+		t.Parallel()
+		m := newMockedLP(t, skipToBlockOpts())
+		err := m.LP.SkipToBlock(ctx, 1)
+		require.ErrorContains(t, err, "must be >= 2")
+	})
+
+	t.Run("disabled log poller returns error", func(t *testing.T) {
+		t.Parallel()
+		err := LogPollerDisabled.SkipToBlock(ctx, 2)
+		require.ErrorIs(t, err, ErrDisabled)
+	})
+
+	t.Run("RPC fetch error", func(t *testing.T) {
+		t.Parallel()
+		m := newMockedLP(t, skipToBlockOpts())
+		m.Client.EXPECT().HeaderByNumberWithOpts(
+			mock.Anything,
+			big.NewInt(2),
+			evmtypes.HeaderByNumberOpts{ConfidenceLevel: primitives.Finalized},
+		).Return(nil, errors.New("rpc unavailable")).Once()
+
+		err := m.LP.SkipToBlock(ctx, 3)
+		require.ErrorContains(t, err, "failed to fetch anchor block 2 from RPC")
+		require.ErrorContains(t, err, "rpc unavailable")
+	})
+
+	t.Run("invalid anchor header", func(t *testing.T) {
+		t.Parallel()
+		m := newMockedLP(t, skipToBlockOpts())
+		m.Client.EXPECT().HeaderByNumberWithOpts(
+			mock.Anything,
+			big.NewInt(2),
+			evmtypes.HeaderByNumberOpts{ConfidenceLevel: primitives.Finalized},
+		).RunAndReturn(func(_ context.Context, _ *big.Int, _ evmtypes.HeaderByNumberOpts) (*evmtypes.Header, error) {
+			head := newHeadVal(2)
+			head.Hash = common.Hash{}
+			return (*evmtypes.Header)(&head), nil
+		}).Once()
+
+		err := m.LP.SkipToBlock(ctx, 3)
+		require.ErrorContains(t, err, "failed to validate anchor block 2")
+	})
+
+	t.Run("forward skip on empty DB", func(t *testing.T) {
+		t.Parallel()
+		m := newMockedLP(t, skipToBlockOpts())
+		expectFinalizedAnchorHeader(t, m.Client, 2)
+		m.ORM.EXPECT().SelectLatestBlock(mock.Anything).Return(nil, sql.ErrNoRows).Once()
+		expectStoreNewFinalizedCheckpoint(t, m.ORM, 2, 2)
+
+		require.NoError(t, m.LP.SkipToBlock(ctx, 3))
+		assert.Equal(t, int64(2), m.LP.backupPollerNextBlock)
+	})
+
+	t.Run("Happy path", func(t *testing.T) {
+		t.Parallel()
+		m := newMockedLP(t, skipToBlockOpts())
+		expectFinalizedAnchorHeader(t, m.Client, 5)
+		m.ORM.EXPECT().SelectLatestBlock(mock.Anything).Return(&Block{
+			BlockNumber:          4,
+			FinalizedBlockNumber: 2,
+			SafeBlockNumber:      2,
+		}, nil).Once()
+		expectStoreNewFinalizedCheckpoint(t, m.ORM, 5, 3)
+
+		require.NoError(t, m.LP.SkipToBlock(ctx, 6))
+	})
+
+	t.Run("backward skip removes blocks from anchor onward", func(t *testing.T) {
+		t.Parallel()
+		m := newMockedLP(t, skipToBlockOpts())
+		expectFinalizedAnchorHeader(t, m.Client, 2)
+		m.ORM.EXPECT().SelectLatestBlock(mock.Anything).Return(&Block{
+			BlockNumber:          4,
+			FinalizedBlockNumber: 3,
+			SafeBlockNumber:      3,
+		}, nil).Once()
+		expectStoreNewFinalizedCheckpoint(t, m.ORM, 2, 2)
+
+		require.NoError(t, m.LP.SkipToBlock(ctx, 3))
+	})
+
+	t.Run("select latest block error", func(t *testing.T) {
+		t.Parallel()
+		m := newMockedLP(t, skipToBlockOpts())
+		expectFinalizedAnchorHeader(t, m.Client, 2)
+		m.ORM.EXPECT().SelectLatestBlock(mock.Anything).Return(nil, errors.New("db unavailable")).Once()
+
+		err := m.LP.SkipToBlock(ctx, 3)
+		require.ErrorContains(t, err, "failed to select latest block")
+	})
+
+	t.Run("store checkpoint error", func(t *testing.T) {
+		t.Parallel()
+		m := newMockedLP(t, skipToBlockOpts())
+		expectFinalizedAnchorHeader(t, m.Client, 2)
+		m.ORM.EXPECT().SelectLatestBlock(mock.Anything).Return(nil, sql.ErrNoRows).Once()
+		m.ORM.EXPECT().StoreNewFinalizedCheckpoint(mock.Anything, mock.Anything, int64(2)).
+			Return(errors.New("db write failed")).Once()
+
+		err := m.LP.SkipToBlock(ctx, 3)
+		require.ErrorContains(t, err, "failed to store new finalized checkpoint")
+	})
 }

--- a/pkg/logpoller/mock_orm_test.go
+++ b/pkg/logpoller/mock_orm_test.go
@@ -1460,6 +1460,54 @@ func (_c *MockORM_SelectLatestFinalizedBlock_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// StoreNewFinalizedCheckpoint provides a mock function with given fields: ctx, block, minBlockToPrune
+func (_m *MockORM) StoreNewFinalizedCheckpoint(ctx context.Context, block Block, minBlockToPrune int64) error {
+	ret := _m.Called(ctx, block, minBlockToPrune)
+
+	if len(ret) == 0 {
+		panic("no return value specified for StoreNewFinalizedCheckpoint")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, Block, int64) error); ok {
+		r0 = rf(ctx, block, minBlockToPrune)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockORM_StoreNewFinalizedCheckpoint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StoreNewFinalizedCheckpoint'
+type MockORM_StoreNewFinalizedCheckpoint_Call struct {
+	*mock.Call
+}
+
+// StoreNewFinalizedCheckpoint is a helper method to define mock.On call
+//   - ctx context.Context
+//   - block Block
+//   - minBlockToPrune int64
+func (_e *MockORM_Expecter) StoreNewFinalizedCheckpoint(ctx interface{}, block interface{}, minBlockToPrune interface{}) *MockORM_StoreNewFinalizedCheckpoint_Call {
+	return &MockORM_StoreNewFinalizedCheckpoint_Call{Call: _e.mock.On("StoreNewFinalizedCheckpoint", ctx, block, minBlockToPrune)}
+}
+
+func (_c *MockORM_StoreNewFinalizedCheckpoint_Call) Run(run func(ctx context.Context, block Block, minBlockToPrune int64)) *MockORM_StoreNewFinalizedCheckpoint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(Block), args[2].(int64))
+	})
+	return _c
+}
+
+func (_c *MockORM_StoreNewFinalizedCheckpoint_Call) Return(_a0 error) *MockORM_StoreNewFinalizedCheckpoint_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockORM_StoreNewFinalizedCheckpoint_Call) RunAndReturn(run func(context.Context, Block, int64) error) *MockORM_StoreNewFinalizedCheckpoint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SelectLatestLogByEventSigWithConfs provides a mock function with given fields: ctx, eventSig, address, confs
 func (_m *MockORM) SelectLatestLogByEventSigWithConfs(ctx context.Context, eventSig common.Hash, address common.Address, confs types.Confirmations) (*Log, error) {
 	ret := _m.Called(ctx, eventSig, address, confs)

--- a/pkg/logpoller/mocks/log_poller.go
+++ b/pkg/logpoller/mocks/log_poller.go
@@ -1758,6 +1758,53 @@ func (_c *LogPoller_ReplayAsync_Call) RunAndReturn(run func(int64)) *LogPoller_R
 	return _c
 }
 
+// SkipToBlock provides a mock function with given fields: ctx, blockNumber
+func (_m *LogPoller) SkipToBlock(ctx context.Context, blockNumber int64) error {
+	ret := _m.Called(ctx, blockNumber)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SkipToBlock")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
+		r0 = rf(ctx, blockNumber)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// LogPoller_SkipToBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SkipToBlock'
+type LogPoller_SkipToBlock_Call struct {
+	*mock.Call
+}
+
+// SkipToBlock is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blockNumber int64
+func (_e *LogPoller_Expecter) SkipToBlock(ctx interface{}, blockNumber interface{}) *LogPoller_SkipToBlock_Call {
+	return &LogPoller_SkipToBlock_Call{Call: _e.mock.On("SkipToBlock", ctx, blockNumber)}
+}
+
+func (_c *LogPoller_SkipToBlock_Call) Run(run func(ctx context.Context, blockNumber int64)) *LogPoller_SkipToBlock_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *LogPoller_SkipToBlock_Call) Return(_a0 error) *LogPoller_SkipToBlock_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *LogPoller_SkipToBlock_Call) RunAndReturn(run func(context.Context, int64) error) *LogPoller_SkipToBlock_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Start provides a mock function with given fields: _a0
 func (_m *LogPoller) Start(_a0 context.Context) error {
 	ret := _m.Called(_a0)

--- a/pkg/logpoller/observability.go
+++ b/pkg/logpoller/observability.go
@@ -102,6 +102,12 @@ func (o *ObservedORM) DeleteExpiredLogs(ctx context.Context, limit int64) (int64
 	})
 }
 
+func (o *ObservedORM) StoreNewFinalizedCheckpoint(ctx context.Context, block Block, minBlockToPrune int64) error {
+	return withObservedExec(ctx, o, "StoreNewFinalizedCheckpoint", metrics.Create, func() error {
+		return o.ORM.StoreNewFinalizedCheckpoint(ctx, block, minBlockToPrune)
+	})
+}
+
 func (o *ObservedORM) SelectUnmatchedLogIDs(ctx context.Context, limit int64) (ids []uint64, err error) {
 	return withObservedQueryAndResults[uint64](ctx, o, "SelectUnmatchedLogIDs", func() ([]uint64, error) {
 		return o.ORM.SelectUnmatchedLogIDs(ctx, limit)

--- a/pkg/logpoller/orm.go
+++ b/pkg/logpoller/orm.go
@@ -67,6 +67,8 @@ type ORM interface {
 
 	// FilteredLogs accepts chainlink-common filtering DSL.
 	FilteredLogs(ctx context.Context, filter []query.Expression, limitAndSort query.LimitAndSort, queryName string) ([]Log, error)
+
+	StoreNewFinalizedCheckpoint(ctx context.Context, block Block, minBlockToPrune int64) error
 }
 
 type DSORM struct {
@@ -114,6 +116,10 @@ func (o *DSORM) InsertBlock(ctx context.Context, blockHash common.Hash, blockNum
 }
 
 func (o *DSORM) InsertBlocks(ctx context.Context, blocks []Block) error {
+	return insertBlocks(ctx, o, blocks)
+}
+
+func insertBlocks(ctx context.Context, o *DSORM, blocks []Block) error {
 	const q = `INSERT INTO evm.log_poller_blocks
 				(evm_chain_id, block_hash, block_number, block_timestamp, finalized_block_number, created_at, safe_block_number)
       		VALUES (:evm_chain_id, :block_hash, :block_number, :block_timestamp, :finalized_block_number, NOW(), :safe_block_number)
@@ -411,38 +417,57 @@ func (o *DSORM) DeleteBlocksBefore(ctx context.Context, end int64, limit int64) 
 	return q.ExecPagedQuery(ctx, limit, end)
 }
 
+func (o *DSORM) StoreNewFinalizedCheckpoint(ctx context.Context, block Block, minBlockToPrune int64) error {
+	return o.Transact(ctx, func(orm *DSORM) error {
+		err := deleteLogsAndBlockAfter(ctx, orm, minBlockToPrune)
+		if err != nil {
+			return fmt.Errorf("failed to delete logs and block after minBlockToPrune %d: %w", minBlockToPrune, err)
+		}
+
+		err = insertBlocks(ctx, orm, []Block{block})
+		if err != nil {
+			return fmt.Errorf("failed to insert new finalized checkpoint block %d: %w", block.BlockNumber, err)
+		}
+		return nil
+	})
+}
+
 func (o *DSORM) DeleteLogsAndBlocksAfter(ctx context.Context, start int64) error {
 	// These deletes are bounded by reorg depth, so they are
 	// fast and should not slow down the log readers.
 	return o.Transact(ctx, func(orm *DSORM) error {
-		// Applying upper bound filter is critical for Postgres performance (especially for evm.logs table)
-		// because it allows the planner to properly estimate the number of rows to be scanned.
-		// If not applied, these queries can become very slow. After some critical number
-		// of logs, Postgres will try to scan all the logs in the index by block_number.
-		// Latency without upper bound filter can be orders of magnitude higher for large number of logs.
-		_, err := orm.ds.ExecContext(ctx, `DELETE FROM evm.log_poller_blocks
+		return deleteLogsAndBlockAfter(ctx, orm, start)
+	})
+}
+
+func deleteLogsAndBlockAfter(ctx context.Context, orm *DSORM, start int64) error {
+	// Applying upper bound filter is critical for Postgres performance (especially for evm.logs table)
+	// because it allows the planner to properly estimate the number of rows to be scanned.
+	// If not applied, these queries can become very slow. After some critical number
+	// of logs, Postgres will try to scan all the logs in the index by block_number.
+	// Latency without upper bound filter can be orders of magnitude higher for large number of logs.
+	_, err := orm.ds.ExecContext(ctx, `DELETE FROM evm.log_poller_blocks
        						WHERE evm_chain_id = $1
 							AND block_number >= $2
 							AND block_number <= (SELECT MAX(block_number)
 						 		FROM evm.log_poller_blocks
 						 		WHERE evm_chain_id = $1)`,
-			sqlutil.New(o.chainID), start)
-		if err != nil {
-			o.lggr.Warnw("Unable to clear reorged blocks, retrying", "err", err)
-			return err
-		}
+		sqlutil.New(orm.chainID), start)
+	if err != nil {
+		orm.lggr.Warnw("Unable to clear reorged blocks, retrying", "err", err)
+		return err
+	}
 
-		_, err = orm.ds.ExecContext(ctx, `DELETE FROM evm.logs
+	_, err = orm.ds.ExecContext(ctx, `DELETE FROM evm.logs
        						WHERE evm_chain_id = $1
 							AND block_number >= $2
 							AND block_number <= (SELECT MAX(block_number) FROM evm.logs WHERE evm_chain_id = $1)`,
-			sqlutil.New(o.chainID), start)
-		if err != nil {
-			o.lggr.Warnw("Unable to clear reorged logs, retrying", "err", err)
-			return err
-		}
-		return nil
-	})
+		sqlutil.New(orm.chainID), start)
+	if err != nil {
+		orm.lggr.Warnw("Unable to clear reorged logs, retrying", "err", err)
+		return err
+	}
+	return nil
 }
 
 type Exp struct {

--- a/pkg/logpoller/orm_test.go
+++ b/pkg/logpoller/orm_test.go
@@ -2505,7 +2505,8 @@ func TestSelectLatestFinalizedBlock(t *testing.T) {
 type execCountingSQLxDB struct {
 	*sqlx.DB
 
-	poolExecContext atomic.Int32
+	poolExecContext      atomic.Int32
+	poolNamedExecContext atomic.Int32
 }
 
 func (d *execCountingSQLxDB) PoolExecContextCount() int32 {
@@ -2515,6 +2516,15 @@ func (d *execCountingSQLxDB) PoolExecContextCount() int32 {
 func (d *execCountingSQLxDB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
 	d.poolExecContext.Add(1)
 	return d.DB.ExecContext(ctx, query, args...)
+}
+
+func (d *execCountingSQLxDB) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
+	d.poolNamedExecContext.Add(1)
+	return d.DB.NamedExecContext(ctx, query, arg)
+}
+
+func (d *execCountingSQLxDB) PoolDirectOpCount() int32 {
+	return d.poolExecContext.Load() + d.poolNamedExecContext.Load()
 }
 
 var _ sqlutil.DataSource = (*execCountingSQLxDB)(nil)
@@ -2536,4 +2546,135 @@ func TestDSORM_DeleteLogsAndBlocksAfter_usesTransactionalDataSource(t *testing.T
 	require.Zero(t, wrapped.PoolExecContextCount(),
 		"DeleteLogsAndBlocksAfter must run DELETEs on the transaction DataSource (orm.ds), not the outer pool; "+
 			"otherwise the two deletes are not atomic and this counter would be 2")
+}
+
+func insertBlockRangeWithLogs(
+	t *testing.T,
+	ctx context.Context,
+	th TestHarness,
+	orm logpoller.ORM,
+	start, end int64,
+) {
+	t.Helper()
+
+	var blocks []logpoller.Block
+	var logs []logpoller.Log
+	for i := start; i <= end; i++ {
+		hash := common.HexToHash(fmt.Sprintf("0x%04x", i))
+		blocks = append(blocks, logpoller.Block{
+			EVMChainID:           sqlutil.New(th.ChainID),
+			BlockHash:            hash,
+			BlockNumber:          i,
+			BlockTimestamp:       time.Unix(i*10, 0),
+			FinalizedBlockNumber: i - 2,
+			SafeBlockNumber:      i - 2,
+		})
+		logs = append(logs, GenLog(th.ChainID, 0, i, hash.String(), EmitterABI.Events["Log1"].ID.Bytes(), th.EmitterAddress1))
+	}
+	require.NoError(t, orm.InsertLogsWithBlocks(ctx, logs, blocks))
+}
+
+func finalizedCheckpointBlock(chainID *big.Int, blockNumber int64, hash common.Hash) logpoller.Block {
+	return logpoller.Block{
+		EVMChainID:           sqlutil.New(chainID),
+		BlockHash:            hash,
+		BlockNumber:          blockNumber,
+		BlockTimestamp:       time.Unix(blockNumber*10, 0),
+		FinalizedBlockNumber: blockNumber,
+		SafeBlockNumber:      blockNumber,
+	}
+}
+
+func requireNoBlock(t *testing.T, ctx context.Context, orm logpoller.ORM, blockNumber int64) {
+	t.Helper()
+	_, err := orm.SelectBlockByNumber(ctx, blockNumber)
+	require.Error(t, err)
+	require.True(t, pkgerrors.Is(err, sql.ErrNoRows))
+}
+
+func TestDSORM_StoreNewFinalizedCheckpoint(t *testing.T) {
+	t.Parallel()
+	testutils.SkipShortDB(t)
+
+	ctx := testutils.Context(t)
+
+	t.Run("forward skip prunes from minBlockToPrune and stores anchor", func(t *testing.T) {
+		th := SetupTH(t, lpOpts)
+		o1 := th.ORM
+		insertBlockRangeWithLogs(t, ctx, th, o1, 1, 4)
+
+		anchor := finalizedCheckpointBlock(th.ChainID, 5, common.HexToHash("0x0005"))
+		require.NoError(t, o1.StoreNewFinalizedCheckpoint(ctx, anchor, 3))
+
+		b, err := o1.SelectBlockByNumber(ctx, 5)
+		require.NoError(t, err)
+		require.Equal(t, int64(5), b.BlockNumber)
+		require.Equal(t, common.HexToHash("0x0005"), b.BlockHash)
+		require.Equal(t, int64(5), b.FinalizedBlockNumber)
+
+		for _, n := range []int64{1, 2} {
+			_, err := o1.SelectBlockByNumber(ctx, n)
+			require.NoError(t, err)
+		}
+		for _, n := range []int64{3, 4} {
+			requireNoBlock(t, ctx, o1, n)
+		}
+
+		logs, err := o1.SelectLogsByBlockRange(ctx, 1, 5)
+		require.NoError(t, err)
+		require.Len(t, logs, 2)
+		for _, lg := range logs {
+			require.Less(t, lg.BlockNumber, int64(3))
+		}
+	})
+
+	t.Run("empty DB stores anchor only", func(t *testing.T) {
+		th := SetupTH(t, lpOpts)
+		o1 := th.ORM
+		anchor := finalizedCheckpointBlock(th.ChainID, 5, common.HexToHash("0x0005"))
+		require.NoError(t, o1.StoreNewFinalizedCheckpoint(ctx, anchor, 5))
+
+		b, err := o1.SelectBlockByNumber(ctx, 5)
+		require.NoError(t, err)
+		require.Equal(t, int64(5), b.BlockNumber)
+
+		logs, err := o1.SelectLogsByBlockRange(ctx, 1, 5)
+		require.NoError(t, err)
+		require.Empty(t, logs)
+	})
+
+	t.Run("does not affect other chain", func(t *testing.T) {
+		th := SetupTH(t, lpOpts)
+		o1 := th.ORM
+		o2 := th.ORM2
+		insertBlockRangeWithLogs(t, ctx, th, o1, 1, 4)
+		require.NoError(t, o2.InsertBlock(ctx, common.HexToHash("0x9999"), 10, time.Now(), 10, 10))
+
+		anchor := finalizedCheckpointBlock(th.ChainID, 2, common.HexToHash("0x0002"))
+		require.NoError(t, o1.StoreNewFinalizedCheckpoint(ctx, anchor, 2))
+
+		b, err := o2.SelectBlockByNumber(ctx, 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(10), b.BlockNumber)
+	})
+}
+
+func TestDSORM_StoreNewFinalizedCheckpoint_usesTransactionalDataSource(t *testing.T) {
+	t.Parallel()
+	testutils.SkipShortDB(t)
+
+	ctx := testutils.Context(t)
+	base := testutils.NewSqlxDB(t)
+	require.NotNil(t, base)
+	wrapped := &execCountingSQLxDB{DB: base}
+
+	chainID := testutils.NewRandomEVMChainID()
+	orm := logpoller.NewORM(chainID, wrapped, logger.Test(t))
+
+	anchor := finalizedCheckpointBlock(chainID, 5, common.HexToHash("0x0005"))
+	require.NoError(t, orm.StoreNewFinalizedCheckpoint(ctx, anchor, 5))
+
+	require.Zero(t, wrapped.PoolDirectOpCount(),
+		"StoreNewFinalizedCheckpoint must run DELETEs and INSERT on the transaction DataSource (orm.ds), not the outer pool; "+
+			"otherwise the prune and checkpoint write are not atomic and this counter would be 3")
 }

--- a/pkg/relay/evm_service.go
+++ b/pkg/relay/evm_service.go
@@ -373,6 +373,13 @@ func (e *evmService) GetLatestLPBlock(ctx context.Context) (*evm.LPBlock, error)
 	}, nil
 }
 
+func (e *evmService) LPSkipToBlock(ctx context.Context, blockNumber int64) error {
+	if err := e.chain.LogPoller().SkipToBlock(ctx, blockNumber); err != nil {
+		return fmt.Errorf("failed to skip log poller to block %d: %w", blockNumber, err)
+	}
+	return nil
+}
+
 func (r *Relayer) GetForwarderForEOA(ctx context.Context, eoa, ocr2AggregatorID evm.Address, pluginType string) (forwarder evm.Address, err error) {
 	if pluginType == string(commontypes.Median) {
 		return r.chain.TxManager().GetForwarderForEOAOCR2Feeds(ctx, eoa, ocr2AggregatorID)


### PR DESCRIPTION
In some cases, RPC may be missing a block (due to migration to a new RPC client).

If a product can confirm that the missing block range contains no interesting events, it should be possible to force LogPoller to resume processing for the new block.