### PR TITLE
Bump chainlink-protos/svr to v1.3.0 and emit per-OFA gas limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-framework/metrics v0.0.0-20260521164805-26d78d5e1243
 	github.com/smartcontractkit/chainlink-framework/multinode v0.0.0-20260521164805-26d78d5e1243
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260622152157-c8e129347b8b
-	github.com/smartcontractkit/chainlink-protos/svr v1.2.0
+	github.com/smartcontractkit/chainlink-protos/svr v1.3.0
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad
 	github.com/smartcontractkit/libocr v0.0.0-20260529134643-c101335a64cd

--- a/go.sum
+++ b/go.sum
@@ -686,8 +686,8 @@ github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-202605122
 github.com/smartcontractkit/chainlink-protos/linking-service/go v0.0.0-20260512230622-65f10f4cd305/go.mod h1:qSTSwX3cBP3FKQwQacdjArqv0g6QnukjV4XuzO6UyoY=
 github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260709145319-7782fb89eb16 h1:/vkKPJoweLkRd56V4YHGRAtTG4+/JAlgklGEfvH6l4c=
 github.com/smartcontractkit/chainlink-protos/node-platform v0.0.0-20260709145319-7782fb89eb16/go.mod h1:dkR2uYg9XYJuT1JASkPzWE51jjFkVb86P7a/yXe5/GM=
-github.com/smartcontractkit/chainlink-protos/svr v1.2.0 h1:7jjgqRgORQS/ikL3z0ZgJy95pzjhR9LuU1TVWg4BZ78=
-github.com/smartcontractkit/chainlink-protos/svr v1.2.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
+github.com/smartcontractkit/chainlink-protos/svr v1.3.0 h1:vOw+MbXtkPK8l/hA7uLASIgCwv05YzmuoIMuOXPa+g0=
+github.com/smartcontractkit/chainlink-protos/svr v1.3.0/go.mod h1:TcOliTQU6r59DwG4lo3U+mFM9WWyBHGuFkkxQpvSujo=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260528173149-f5b8336b19d9 h1:LQy2j2+TdKLSWsUTUYuqmQPn8kjqCLjGI3ZJYGtDc08=
 github.com/smartcontractkit/chainlink-protos/workflows/go v0.0.0-20260528173149-f5b8336b19d9/go.mod h1:GTpDgyK0OObf7jpch6p8N281KxN92wbB8serZhU9yRc=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 h1:7bxYNrPpygn8PUSBiEKn8riMd7CXMi/4bjTy0fHhcrY=

--- a/pkg/txm/clientwrappers/dualbroadcast/ofa_backend.go
+++ b/pkg/txm/clientwrappers/dualbroadcast/ofa_backend.go
@@ -177,7 +177,7 @@ func (d *ofaBackend) sendDualBroadcastTx(ctx context.Context, tx *types.Transact
 	start := time.Now()
 	_, err = d.postJSONRPC(ctx, tx.FromAddress, body, meta)
 	d.metrics.RecordSendTx(ctx, time.Since(start), err)
-	if emitErr := txm.EmitTxMessage(ctx, d.metrics.chainID, attemptWithOFAGasTier.Hash, tx.FromAddress, tx); emitErr != nil {
+	if emitErr := txm.EmitTxMessage(ctx, d.metrics.chainID, attemptWithOFAGasTier.Hash, tx.FromAddress, tx, attemptWithOFAGasTier.GasLimit); emitErr != nil {
 		d.lggr.Errorw("Beholder error emitting tx message", "err", emitErr, "transactionLifecycleID", tx.GetTransactionLifecycleID(d.lggr))
 	}
 

--- a/pkg/txm/metrics.go
+++ b/pkg/txm/metrics.go
@@ -58,7 +58,7 @@ type Metrics interface {
 	ReachedMaxAttempts(context.Context, bool)
 	RecordTimeUntilTxConfirmed(context.Context, float64)
 	SetRPCNonce(context.Context, common.Address, uint64)
-	EmitTxMessage(context.Context, common.Hash, common.Address, *types.Transaction) error
+	EmitTxMessage(ctx context.Context, txHash common.Hash, fromAddress common.Address, tx *types.Transaction, gasLimit uint64) error
 }
 
 // txmMetrics is the default metrics recorder for the TXMv2 transaction lifecycle.
@@ -194,11 +194,11 @@ func (m *txmMetrics) SetRPCNonce(ctx context.Context, address common.Address, no
 	m.rpcNonce.Record(ctx, int64(nonce))
 }
 
-func (m *txmMetrics) EmitTxMessage(ctx context.Context, txHash common.Hash, fromAddress common.Address, tx *types.Transaction) error {
-	return EmitTxMessage(ctx, m.chainID.String(), txHash, fromAddress, tx)
+func (m *txmMetrics) EmitTxMessage(ctx context.Context, txHash common.Hash, fromAddress common.Address, tx *types.Transaction, gasLimit uint64) error {
+	return EmitTxMessage(ctx, m.chainID.String(), txHash, fromAddress, tx, gasLimit)
 }
 
-func EmitTxMessage(ctx context.Context, chainID string, txHash common.Hash, fromAddress common.Address, tx *types.Transaction) error {
+func EmitTxMessage(ctx context.Context, chainID string, txHash common.Hash, fromAddress common.Address, tx *types.Transaction, gasLimit uint64) error {
 	meta, err := tx.GetMeta()
 	if err != nil {
 		return fmt.Errorf("failed to get meta for tx %s: %w", txHash, err)
@@ -228,6 +228,10 @@ func EmitTxMessage(ctx context.Context, chainID string, txHash common.Hash, from
 		ChainId:             chainID,
 		FeedAddress:         destAddress,
 		DualBroadcastParams: dualBroadcastParams,
+	}
+
+	if gasLimit != 0 {
+		message.GasLimit = &gasLimit
 	}
 
 	messageBytes, err := proto.Marshal(message)
@@ -262,6 +266,6 @@ func (noopTxmMetrics) RecordTimeUntilTxConfirmed(context.Context, float64) {}
 
 func (noopTxmMetrics) SetRPCNonce(context.Context, common.Address, uint64) {}
 
-func (noopTxmMetrics) EmitTxMessage(context.Context, common.Hash, common.Address, *types.Transaction) error {
+func (noopTxmMetrics) EmitTxMessage(context.Context, common.Hash, common.Address, *types.Transaction, uint64) error {
 	return nil
 }

--- a/pkg/txm/metrics.go
+++ b/pkg/txm/metrics.go
@@ -58,7 +58,7 @@ type Metrics interface {
 	ReachedMaxAttempts(context.Context, bool)
 	RecordTimeUntilTxConfirmed(context.Context, float64)
 	SetRPCNonce(context.Context, common.Address, uint64)
-	EmitTxMessage(ctx context.Context, txHash common.Hash, fromAddress common.Address, tx *types.Transaction, gasLimit uint64) error
+	EmitTxMessage(context.Context, common.Hash, common.Address, *types.Transaction, uint64) error
 }
 
 // txmMetrics is the default metrics recorder for the TXMv2 transaction lifecycle.
@@ -219,6 +219,11 @@ func EmitTxMessage(ctx context.Context, chainID string, txHash common.Hash, from
 		dualBroadcastParams = meta.DualBroadcastParams
 	}
 
+	var gasLimitPtr *uint64
+	if gasLimit != 0 {
+		gasLimitPtr = &gasLimit
+	}
+
 	message := &svrv1.TxMessage{
 		Hash:                txHash.String(),
 		FromAddress:         fromAddress.String(),
@@ -228,10 +233,7 @@ func EmitTxMessage(ctx context.Context, chainID string, txHash common.Hash, from
 		ChainId:             chainID,
 		FeedAddress:         destAddress,
 		DualBroadcastParams: dualBroadcastParams,
-	}
-
-	if gasLimit != 0 {
-		message.GasLimit = &gasLimit
+		GasLimit:            gasLimitPtr,
 	}
 
 	messageBytes, err := proto.Marshal(message)

--- a/pkg/txm/metrics_test.go
+++ b/pkg/txm/metrics_test.go
@@ -52,6 +52,7 @@ func TestEmitTxMessage(t *testing.T) {
 			expectedHash,
 			fromAddress,
 			tx,
+			0,
 		)
 		require.NoError(t, err)
 
@@ -101,6 +102,7 @@ func TestEmitTxMessage(t *testing.T) {
 			expectedHash,
 			fromAddress,
 			tx,
+			0,
 		)
 		require.NoError(t, err)
 
@@ -129,6 +131,7 @@ func TestEmitTxMessage(t *testing.T) {
 		expectedNonce := uint64(7)
 		expectedChain := testutils.FixtureChainID
 		expectedParams := "hint=calldata&hint=logs&builder=flashbots"
+		expectedGasLimit := uint64(210000)
 		isDualBroadcast := true
 
 		metaBytes, err := json.Marshal(types.TxMeta{
@@ -149,7 +152,7 @@ func TestEmitTxMessage(t *testing.T) {
 		}
 
 		// WHEN
-		err = txmMetrics.EmitTxMessage(ctx, common.Hash{}, fromAddress, tx)
+		err = txmMetrics.EmitTxMessage(ctx, common.Hash{}, fromAddress, tx, expectedGasLimit)
 		require.NoError(t, err)
 
 		// THEN
@@ -162,6 +165,41 @@ func TestEmitTxMessage(t *testing.T) {
 
 		require.NotNil(t, actualMessage.DualBroadcastParams)
 		assert.Equal(t, expectedParams, *actualMessage.DualBroadcastParams)
+		require.NotNil(t, actualMessage.GasLimit)
+		assert.Equal(t, expectedGasLimit, *actualMessage.GasLimit)
+	})
+
+	t.Run("does not set gas_limit when gasLimit is zero", func(t *testing.T) {
+		// GIVEN
+		ctx := t.Context()
+		beholderTester := beholdertest.NewObserver(t)
+
+		fromAddress := testutils.NewAddress()
+		expectedNonce := uint64(9)
+		expectedChain := testutils.FixtureChainID
+
+		txmMetrics := NewTxmMetrics(logger.Test(t), expectedChain)
+
+		tx := &types.Transaction{
+			IsPurgeable: false,
+			FromAddress: fromAddress,
+			ToAddress:   testutils.NewAddress(),
+			Nonce:       &expectedNonce,
+		}
+
+		// WHEN
+		err := txmMetrics.EmitTxMessage(ctx, common.Hash{}, fromAddress, tx, 0)
+		require.NoError(t, err)
+
+		// THEN
+		messages := beholderTester.Messages(t)
+		assert.Len(t, messages, 1)
+
+		var actualMessage svrv1.TxMessage
+		err = proto.Unmarshal(messages[0].Body, &actualMessage)
+		require.NoError(t, err)
+
+		assert.Nil(t, actualMessage.GasLimit)
 	})
 
 	t.Run("does not set dual_broadcast_params for a primary (non-dual-broadcast) tx", func(t *testing.T) {
@@ -184,7 +222,7 @@ func TestEmitTxMessage(t *testing.T) {
 		}
 
 		// WHEN
-		err := txmMetrics.EmitTxMessage(ctx, common.Hash{}, fromAddress, tx)
+		err := txmMetrics.EmitTxMessage(ctx, common.Hash{}, fromAddress, tx, 0)
 		require.NoError(t, err)
 
 		// THEN
@@ -245,5 +283,5 @@ func TestNoopTxmMetrics(t *testing.T) {
 		m.RecordTimeUntilTxConfirmed(ctx, 1)
 		m.SetRPCNonce(ctx, address, nonce)
 	})
-	assert.NoError(t, m.EmitTxMessage(ctx, common.Hash{}, address, &types.Transaction{Nonce: &nonce}))
+	assert.NoError(t, m.EmitTxMessage(ctx, common.Hash{}, address, &types.Transaction{Nonce: &nonce}, 0))
 }

--- a/pkg/txm/txm.go
+++ b/pkg/txm/txm.go
@@ -363,7 +363,7 @@ func (t *Txm) sendTransactionWithError(ctx context.Context, tx *types.Transactio
 	}
 
 	t.metrics.IncrementNumBroadcastedTxs(ctx)
-	if err = t.metrics.EmitTxMessage(ctx, attempt.Hash, fromAddress, tx); err != nil {
+	if err = t.metrics.EmitTxMessage(ctx, attempt.Hash, fromAddress, tx, attempt.GasLimit); err != nil {
 		t.lggr.Errorw("Beholder error emitting tx message", "err", err)
 	}
 


### PR DESCRIPTION
## What                                                                                                                                                                                              
                                                                                                                                                                                                       
- Bumps `github.com/smartcontractkit/chainlink-protos/svr` from `v1.2.0` → `v1.3.0`, which adds the optional `gas_limit` field (9) to the `TxMessage` proto.                                         
- Plumbs the per-OFA "accountability" (OFA-tiered) gas limit into the emitted SVR `TxMessage.GasLimit`.                                                                                              
                                                                                                                                                                                                       
## Why                                                                                                                                                                                               
                                                                                                                                                                                                       
The OFA gas tier reserves the last two digits of the gas limit per OFA backend so an on-chain transaction can be attributed to a specific OFA (e.g. Titan / MEV-Share) for auction and performance comparison. Until now that tiered limit was computed at broadcast time but never made it into the beholder `TxMessage`, so downstream consumers couldn't attribute transactions.  

Builds on top of #462 