### PR TITLE
Safeguard FeeHistory Estimator

### DIFF
--- a/pkg/gas/docs/FEE_HISTORY_ESTIMATOR.md
+++ b/pkg/gas/docs/FEE_HISTORY_ESTIMATOR.md
@@ -14,9 +14,10 @@ The rest of the configs are only applicable when `EIP1559` is enabled
 - `RewardPercentile`: specifies which fee percentile to pick from for each processed past block. 
 
 ### Validations
-During startup, the estimator will perform two config checks:
+During startup, the estimator will perform three config checks:
 - `BumpPercent` is equal to or higher than *MinimumBumpPercentage*. *MinimumBumpPercentage* is fixed at 10% and it's the minimum percentage allowed by Geth when bumping a transaction, to prevent spam attacks. Replacing a transaction with a price less than 10% from the previous one will result in an error on the RPC side. Even for chains that don't enforce that rule, a 10% bump seems reasonable.
 - `RewardPercentile` is equal or lower than *ConnectivityPercentile*, when `EIP1559` is enabled. *ConnectivityPercentile* is fixed at the 85th percentile and it's the maximum percentile we're willing to bump a transaction's price. This is used as a sanity check method in order to avoid excessive gas bumping when an RPC is not responding.
+- `CacheTimeout` is equal to or higher than *MinimumCacheTimeout*.
 
 ## As a Service
 `Fee History` estimator is built as a service. This means it will periodically poll the RPC for new prices, perform off-chain calculations, and cache the result for future use. For simplicity, only one type of gas estimation can be enabled at a time, Legacy or Dynamic. The poll interval is controlled by `CacheTimeout`. This value should be close to the block time. For slower chains, like Ethereum, you can set it to 12s, the same as the block time. For faster chains, you can skip a block or two, as prices will be refreshed more frequently. Ideally, 1s should be the absolute minimum. 

--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -224,7 +224,7 @@ func (f *FeeHistoryEstimator) GetMaxDynamicFee(maxPrice *assets.Wei) (fee Dynami
 		return fee, err
 	}
 	maxFeeCap := nextBaseFee.AddPercentage(BaseFeeBufferPercentage).Add(priorityFeeThreshold)
-	return DynamicFee{GasFeeCap: maxFeeCap, GasTipCap: priorityFeeThreshold}, nil
+	return DynamicFee{GasFeeCap: assets.WeiMin(maxFeeCap, maxPrice), GasTipCap: assets.WeiMin(priorityFeeThreshold, maxPrice)}, nil
 }
 
 // RefreshDynamicPrice uses eth_feeHistory to fetch the baseFee of the next block and the Nth maxPriorityFeePerGas percentiles

--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -26,6 +26,7 @@ const (
 	MinimumBumpPercentage   = 10 // based on geth's spec
 	ConnectivityPercentile  = 85
 	BaseFeeBufferPercentage = 40
+	MinimumCacheTimeout     = 250 * time.Millisecond
 )
 
 type FeeHistoryEstimatorConfig struct {
@@ -95,6 +96,9 @@ func (f *FeeHistoryEstimator) Start(context.Context) error {
 		if f.config.EIP1559 && f.config.RewardPercentile > ConnectivityPercentile {
 			return fmt.Errorf("RewardPercentile: %s is greater than maximum allowed percentile: %s",
 				strconv.FormatUint(uint64(f.config.RewardPercentile), 10), strconv.Itoa(ConnectivityPercentile))
+		}
+		if f.config.CacheTimeout < MinimumCacheTimeout {
+			return fmt.Errorf("CacheTimeout: %s must be at least %s", f.config.CacheTimeout, MinimumCacheTimeout)
 		}
 		f.wg.Add(1)
 		go f.run()

--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -51,7 +51,7 @@ type FeeHistoryEstimatorConfig struct {
 	RewardPercentile float64
 }
 
-// dynamicFeeCache holds the cached results of a single RefreshDynamicPrice round.
+// dynamicFeeCache holds the cached results of a single RefreshDynamicFee round.
 type dynamicFeeCache struct {
 	dynamicFee           DynamicFee
 	priorityFeeThreshold *assets.Wei
@@ -226,7 +226,7 @@ func (f *FeeHistoryEstimator) getGasPrice() (*assets.Wei, error) {
 
 // GetDynamicFee will fetch the cached dynamic prices.
 func (f *FeeHistoryEstimator) GetDynamicFee(ctx context.Context, maxPrice *assets.Wei) (fee DynamicFee, err error) {
-	if fee, err = f.getDynamicFeeCache().getDynamicFee(); err != nil {
+	if fee, err = f.getDynamicFeeCacheCopy().getDynamicFee(); err != nil {
 		return
 	}
 
@@ -244,7 +244,7 @@ func (f *FeeHistoryEstimator) GetDynamicFee(ctx context.Context, maxPrice *asset
 }
 
 func (f *FeeHistoryEstimator) GetMaxDynamicFee(maxPrice *assets.Wei) (fee DynamicFee, err error) {
-	cache := f.getDynamicFeeCache()
+	cache := f.getDynamicFeeCacheCopy()
 	priorityFeeThreshold, err := cache.getPriorityFeeThreshold()
 	if err != nil {
 		return fee, err
@@ -275,7 +275,7 @@ func (f *FeeHistoryEstimator) RefreshDynamicFee() error {
 	}
 
 	// Start from the currently cached values so that partial responses only overwrite what they actually carry.
-	cache := f.getDynamicFeeCache()
+	cache := f.getDynamicFeeCacheCopy()
 
 	var nextBlock *big.Int
 	// If the BaseFee list is empty, maintain the cached base fee to continue updating the priority fee threshold.
@@ -300,7 +300,7 @@ func (f *FeeHistoryEstimator) RefreshDynamicFee() error {
 
 	// The two priority fees are always cached as a pair. priorityFeeThreshold is a higher percentile of the very same
 	// sample as maxPriorityFeePerGas, so within a response maxPriorityFeePerGas <= priorityFeeThreshold always holds.
-	// Mixing values from different rounds could invert that and make BumpDynamicFee report a bogus connectivity issue.
+	// Mixing values from different rounds could invert that and make BumpDynamicFee report a false positive connectivity issue.
 	if maxPriorityFeePerGas != nil && priorityFeeThreshold != nil {
 		if maxPriorityFeePerGas.Cmp(priorityFeeThreshold) > 0 {
 			// Only reachable if the RPC returns non-monotonic percentiles. Raise the threshold to keep bumping possible.
@@ -316,9 +316,7 @@ func (f *FeeHistoryEstimator) RefreshDynamicFee() error {
 			"blocks", len(feeHistory.Reward), "maxPriorityFeePerGas", maxPriorityFeePerGas, "priorityFeeThreshold", priorityFeeThreshold)
 	}
 
-	// The fee cap is recomputed even when the priority fees above were retained, because the base fee moves much
-	// faster than they do. It can only be set once a priority fee has been cached at least once, so that the
-	// dynamic fee is never published half-populated.
+	// The fee cap is recomputed even when the priority fees above were retained, to incorporate the latest base fee.
 	if cache.dynamicFee.GasTipCap != nil {
 		cache.dynamicFee.GasFeeCap = cache.nextBaseFee.AddPercentage(f.baseFeeBufferPercentage()).Add(cache.dynamicFee.GasTipCap)
 		f.metrics.RecordMaxFeePerGas(ctx, float64(cache.dynamicFee.GasFeeCap.Int64()))
@@ -372,7 +370,7 @@ func calcPriorityFees(rewards [][]*big.Int) (avg *assets.Wei, threshold *assets.
 }
 
 // baseFeeBufferPercentage returns the safety buffer applied on top of the latest base fee. BlockHistorySize of 0 is used
-// as the signal for a chain without a mempool, which is the only signal the estimator has for it.
+// as the signal for a chain without a mempool.
 func (f *FeeHistoryEstimator) baseFeeBufferPercentage() uint16 {
 	if f.config.BlockHistorySize == 0 {
 		return NoMempoolBaseFeeBufferPercentage
@@ -380,7 +378,7 @@ func (f *FeeHistoryEstimator) baseFeeBufferPercentage() uint16 {
 	return BaseFeeBufferPercentage
 }
 
-func (f *FeeHistoryEstimator) getDynamicFeeCache() dynamicFeeCache {
+func (f *FeeHistoryEstimator) getDynamicFeeCacheCopy() dynamicFeeCache {
 	f.dynamicMu.RLock()
 	defer f.dynamicMu.RUnlock()
 	return f.dynamicFeeCache
@@ -440,7 +438,7 @@ func (f *FeeHistoryEstimator) BumpDynamicFee(ctx context.Context, originalFee Dy
 			fees.ErrBump, originalFee.GasFeeCap, originalFee.GasTipCap, maxPrice)
 	}
 
-	cache := f.getDynamicFeeCache()
+	cache := f.getDynamicFeeCacheCopy()
 	currentDynamicFee, err := cache.getDynamicFee()
 	if err != nil {
 		return

--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -23,10 +23,23 @@ import (
 )
 
 const (
-	MinimumBumpPercentage   = 10 // based on geth's spec
-	ConnectivityPercentile  = 85
+	// MinimumBumpPercentage is the minimum percentage that a bumped fee must be above the original fee.
+	//This is based on geth's spec, which requires a minimum of 10% bump for bumped transactions to be accepted by the RPC.
+	MinimumBumpPercentage = 10
+	// ConnectivityPercentile is the highest percentile of the maxPriorityFeePerGas that we're willing to pay.
+	// If a bumped attempt exceeds this value then there is a good chance there is a connectivity issue and we shouldn't bump.
+	ConnectivityPercentile = 85
+	// BaseFeeBufferPercentage covers the base fee growth until the transaction gets included. It also helps to cover potential
+	// delays from the time the prices are fetched until the transaction is transmitted. On Ethereum the base fee moves by
+	// 12.5% * (gasUsed - target) / target per block. This value covers ~8 blocks at u = 0.67, which is a demand spike rather than regular traffic.
 	BaseFeeBufferPercentage = 40
-	MinimumCacheTimeout     = 500 * time.Millisecond
+	// NoMempoolBaseFeeBufferPercentage covers potential cache staleness and delays from the time the prices are fetched until transmission.
+	// Chains without a mempool sequence transactions almost immediately, so the exposure is the CacheTimeout window
+	// (especially on super fast chains like Arbitrum) rather than the mempool wait.
+	// We avoid using an even larger buffer because even though the excess fee is refunded, it still increases the pre-transactional cost
+	// and can cause the transaction to be rejected with an insufficient funds error.
+	NoMempoolBaseFeeBufferPercentage = 90
+	MinimumCacheTimeout              = 500 * time.Millisecond
 )
 
 type FeeHistoryEstimatorConfig struct {
@@ -36,6 +49,29 @@ type FeeHistoryEstimatorConfig struct {
 	EIP1559          bool
 	BlockHistorySize uint64
 	RewardPercentile float64
+}
+
+// dynamicFeeCache holds the cached results of a single RefreshDynamicPrice round.
+type dynamicFeeCache struct {
+	dynamicFee           DynamicFee
+	priorityFeeThreshold *assets.Wei
+	nextBaseFee          *assets.Wei
+}
+
+// getDynamicFee returns the cached dynamic price, or an error if no refresh has populated it yet.
+func (c dynamicFeeCache) getDynamicFee() (fee DynamicFee, err error) {
+	if c.dynamicFee.GasFeeCap == nil || c.dynamicFee.GasTipCap == nil {
+		return fee, errors.New("dynamic fee not set")
+	}
+	return c.dynamicFee, nil
+}
+
+// getPriorityFeeThreshold returns the cached connectivity threshold, or an error if no refresh has populated it yet.
+func (c dynamicFeeCache) getPriorityFeeThreshold() (*assets.Wei, error) {
+	if c.priorityFeeThreshold == nil {
+		return nil, errors.New("priorityFeeThreshold not set")
+	}
+	return c.priorityFeeThreshold, nil
 }
 
 type feeHistoryEstimatorClient interface {
@@ -54,14 +90,8 @@ type FeeHistoryEstimator struct {
 	gasPriceMu sync.RWMutex
 	gasPrice   *assets.Wei
 
-	dynamicPriceMu sync.RWMutex
-	dynamicPrice   DynamicFee
-
-	priorityFeeThresholdMu sync.RWMutex
-	priorityFeeThreshold   *assets.Wei
-
-	nextBaseFeeMu sync.RWMutex
-	nextBaseFee   *assets.Wei
+	dynamicMu       sync.RWMutex
+	dynamicFeeCache dynamicFeeCache
 
 	l1Oracle rollups.L1Oracle
 
@@ -131,7 +161,7 @@ func (f *FeeHistoryEstimator) run() {
 			t.Reset()
 		case <-t.C:
 			if f.config.EIP1559 {
-				if err := f.RefreshDynamicPrice(); err != nil {
+				if err := f.RefreshDynamicFee(); err != nil {
 					f.logger.Error(err)
 				}
 			} else {
@@ -196,7 +226,7 @@ func (f *FeeHistoryEstimator) getGasPrice() (*assets.Wei, error) {
 
 // GetDynamicFee will fetch the cached dynamic prices.
 func (f *FeeHistoryEstimator) GetDynamicFee(ctx context.Context, maxPrice *assets.Wei) (fee DynamicFee, err error) {
-	if fee, err = f.getDynamicPrice(); err != nil {
+	if fee, err = f.getDynamicFeeCache().getDynamicFee(); err != nil {
 		return
 	}
 
@@ -214,24 +244,24 @@ func (f *FeeHistoryEstimator) GetDynamicFee(ctx context.Context, maxPrice *asset
 }
 
 func (f *FeeHistoryEstimator) GetMaxDynamicFee(maxPrice *assets.Wei) (fee DynamicFee, err error) {
-	priorityFeeThreshold, err := f.getPriorityFeeThreshold()
+	cache := f.getDynamicFeeCache()
+	priorityFeeThreshold, err := cache.getPriorityFeeThreshold()
 	if err != nil {
 		return fee, err
 	}
-
-	nextBaseFee, err := f.getNextBaseFee()
-	if err != nil {
-		return fee, err
+	if cache.nextBaseFee == nil {
+		return fee, errors.New("nextBaseFee not set")
 	}
-	maxFeeCap := nextBaseFee.AddPercentage(BaseFeeBufferPercentage).Add(priorityFeeThreshold)
+	maxFeeCap := cache.nextBaseFee.AddPercentage(f.baseFeeBufferPercentage()).Add(priorityFeeThreshold)
 	return DynamicFee{GasFeeCap: assets.WeiMin(maxFeeCap, maxPrice), GasTipCap: assets.WeiMin(priorityFeeThreshold, maxPrice)}, nil
 }
 
-// RefreshDynamicPrice uses eth_feeHistory to fetch the baseFee of the next block and the Nth maxPriorityFeePerGas percentiles
+// RefreshDynamicFee uses eth_feeHistory to fetch the baseFee of the next block and the Nth maxPriorityFeePerGas percentiles
 // of the past X blocks. It also fetches the highest 85th maxPriorityFeePerGas percentile of the past X blocks, which represents
 // the highest percentile we're willing to pay. A buffer is added on top of the latest baseFee to catch fluctuations in the next
-// blocks. On Ethereum the increase is baseFee * 1.125 per block, however in some chains that may vary.
-func (f *FeeHistoryEstimator) RefreshDynamicPrice() error {
+// blocks. On Ethereum the increase is baseFee * 1.125 per block, however in some chains that may vary. See
+// baseFeeBufferPercentage for how the buffer is picked.
+func (f *FeeHistoryEstimator) RefreshDynamicFee() error {
 	ctx, cancel := f.stopCh.CtxWithTimeout(client.QueryTimeout)
 	defer cancel()
 
@@ -244,86 +274,116 @@ func (f *FeeHistoryEstimator) RefreshDynamicPrice() error {
 		return errors.New("feeHistory result is nil")
 	}
 
-	// If the BaseFee list is empty, maintain the cached base fee to continue updating priorityFeeThresholdWei
-	f.nextBaseFeeMu.RLock()
-	nextBaseFee := f.nextBaseFee
-	f.nextBaseFeeMu.RUnlock()
+	// Start from the currently cached values so that partial responses only overwrite what they actually carry.
+	cache := f.getDynamicFeeCache()
+
+	var nextBlock *big.Int
+	// If the BaseFee list is empty, maintain the cached base fee to continue updating the priority fee threshold.
 	if len(feeHistory.BaseFee) != 0 {
 		// eth_feeHistory doesn't return the latest baseFee of the range but rather the latest + 1, because it can be derived from the existing
 		// values. Source: https://github.com/ethereum/go-ethereum/blob/b0f66e34ca2a4ea7ae23475224451c8c9a569826/eth/gasprice/feehistory.go#L235
-		// nextBlock is the latest returned + 1 to be aligned with the base fee value.
-		nextBaseFee = assets.NewWei(feeHistory.BaseFee[len(feeHistory.BaseFee)-1])
+		cache.nextBaseFee = assets.NewWei(feeHistory.BaseFee[len(feeHistory.BaseFee)-1])
+		nextBlock = new(big.Int).Add(feeHistory.OldestBlock, big.NewInt(int64(len(feeHistory.BaseFee)-1)))
 	}
 	// If the cached base fee is nil and the BaseFee list is empty, return an error since a proper next base fee isn't set
-	if nextBaseFee == nil {
+	if cache.nextBaseFee == nil {
 		return errors.New("nextBaseFee not set")
 	}
-	nextBlock := big.NewInt(0).Add(feeHistory.OldestBlock, big.NewInt(int64(f.config.BlockHistorySize)))
 
 	// If BlockHistorySize is 0 it means priority fees will be ignored from the calculations, so we set them to 0.
-	// If it's not we exclude 0 priced priority fees from the RPC response, even though some networks allow them. For empty blocks, eth_feeHistory
-	// returns priority fees with 0 values so it's safer to discard them in order to pick values from a more representative sample.
-	maxPriorityFeePerGas := assets.NewWeiI(0)
-	priorityFeeThresholdWei := assets.NewWeiI(0)
-	if f.config.BlockHistorySize > 0 {
-		var nonZeroRewardsLen int64
-		priorityFee := big.NewInt(0)
-		priorityFeeThreshold := big.NewInt(0)
-		for _, reward := range feeHistory.Reward {
-			// reward needs to have values for two percentiles. Some chains may return an empty slice instead of 0x0 values, so we use
-			// continue instead of throwing an error.
-			if len(reward) < 2 || reward[0] == nil || reward[1] == nil {
-				continue
-			}
-			// We'll calculate the average of non-zero priority fees
-			if reward[0].Cmp(big.NewInt(0)) > 0 {
-				priorityFee = priorityFee.Add(priorityFee, reward[0])
-				nonZeroRewardsLen++
-			}
-			// We take the max value for the bumping threshold
-			if reward[1].Cmp(big.NewInt(0)) > 0 {
-				priorityFeeThreshold = bigmath.Max(priorityFeeThreshold, reward[1])
-			}
-		}
-
-		if nonZeroRewardsLen == 0 || priorityFeeThreshold.Cmp(big.NewInt(0)) == 0 {
-			return nil
-		}
-		priorityFeeThresholdWei = assets.NewWei(priorityFeeThreshold)
-		maxPriorityFeePerGas = assets.NewWei(priorityFee.Div(priorityFee, big.NewInt(nonZeroRewardsLen)))
+	var maxPriorityFeePerGas, priorityFeeThreshold *assets.Wei
+	if f.config.BlockHistorySize == 0 {
+		maxPriorityFeePerGas, priorityFeeThreshold = assets.NewWeiI(0), assets.NewWeiI(0)
+	} else {
+		maxPriorityFeePerGas, priorityFeeThreshold = calcPriorityFees(feeHistory.Reward)
 	}
 
-	// BaseFeeBufferPercentage is used as a safety to catch any fluctuations in the Base Fee during the next blocks.
-	maxFeePerGas := nextBaseFee.AddPercentage(BaseFeeBufferPercentage).Add(maxPriorityFeePerGas)
-	f.nextBaseFeeMu.Lock()
-	f.nextBaseFee = nextBaseFee
-	f.nextBaseFeeMu.Unlock()
+	// The two priority fees are always cached as a pair. priorityFeeThreshold is a higher percentile of the very same
+	// sample as maxPriorityFeePerGas, so within a response maxPriorityFeePerGas <= priorityFeeThreshold always holds.
+	// Mixing values from different rounds could invert that and make BumpDynamicFee report a bogus connectivity issue.
+	if maxPriorityFeePerGas != nil && priorityFeeThreshold != nil {
+		if maxPriorityFeePerGas.Cmp(priorityFeeThreshold) > 0 {
+			// Only reachable if the RPC returns non-monotonic percentiles. Raise the threshold to keep bumping possible.
+			f.logger.Warnw("eth_feeHistory returned a maxPriorityFeePerGas above its ConnectivityPercentile, raising the threshold to match",
+				"maxPriorityFeePerGas", maxPriorityFeePerGas, "priorityFeeThreshold", priorityFeeThreshold)
+			priorityFeeThreshold = maxPriorityFeePerGas
+		}
+		cache.dynamicFee.GasTipCap = maxPriorityFeePerGas
+		cache.priorityFeeThreshold = priorityFeeThreshold
+		f.metrics.RecordMaxPriorityFeePerGas(ctx, float64(maxPriorityFeePerGas.Int64()))
+	} else {
+		f.logger.Warnw("eth_feeHistory returned no usable priority fees, keeping the previously cached ones",
+			"blocks", len(feeHistory.Reward), "maxPriorityFeePerGas", maxPriorityFeePerGas, "priorityFeeThreshold", priorityFeeThreshold)
+	}
 
-	f.metrics.RecordBaseFee(ctx, float64(nextBaseFee.Int64()))
-	f.metrics.RecordMaxPriorityFeePerGas(ctx, float64(maxPriorityFeePerGas.Int64()))
-	f.metrics.RecordMaxFeePerGas(ctx, float64(maxFeePerGas.Int64()))
+	// The fee cap is recomputed even when the priority fees above were retained, because the base fee moves much
+	// faster than they do. It can only be set once a priority fee has been cached at least once, so that the
+	// dynamic fee is never published half-populated.
+	if cache.dynamicFee.GasTipCap != nil {
+		cache.dynamicFee.GasFeeCap = cache.nextBaseFee.AddPercentage(f.baseFeeBufferPercentage()).Add(cache.dynamicFee.GasTipCap)
+		f.metrics.RecordMaxFeePerGas(ctx, float64(cache.dynamicFee.GasFeeCap.Int64()))
+	}
+
+	f.metrics.RecordBaseFee(ctx, float64(cache.nextBaseFee.Int64()))
 
 	f.logger.Debugf("Fetched new dynamic prices, nextBlock#: %v - oldestBlock#: %v - nextBaseFee: %v - maxFeePerGas: %v - maxPriorityFeePerGas: %v - maxPriorityFeeThreshold: %v",
-		nextBlock, feeHistory.OldestBlock, nextBaseFee, maxFeePerGas, maxPriorityFeePerGas, priorityFeeThresholdWei)
+		nextBlock, feeHistory.OldestBlock, cache.nextBaseFee, cache.dynamicFee.GasFeeCap, cache.dynamicFee.GasTipCap, cache.priorityFeeThreshold)
 
-	f.priorityFeeThresholdMu.Lock()
-	f.priorityFeeThreshold = priorityFeeThresholdWei
-	f.priorityFeeThresholdMu.Unlock()
-
-	f.dynamicPriceMu.Lock()
-	defer f.dynamicPriceMu.Unlock()
-	f.dynamicPrice.GasFeeCap = maxFeePerGas
-	f.dynamicPrice.GasTipCap = maxPriorityFeePerGas
+	f.dynamicMu.Lock()
+	defer f.dynamicMu.Unlock()
+	f.dynamicFeeCache = cache
 	return nil
 }
 
-func (f *FeeHistoryEstimator) getDynamicPrice() (fee DynamicFee, err error) {
-	f.dynamicPriceMu.RLock()
-	defer f.dynamicPriceMu.RUnlock()
-	if f.dynamicPrice.GasFeeCap == nil || f.dynamicPrice.GasTipCap == nil {
-		return fee, errors.New("dynamic price not set")
+// calcPriorityFees returns the average of the non-zero RewardPercentile priority fees and the maximum
+// ConnectivityPercentile priority fee of the given eth_feeHistory rewards. Either value is nil when the
+// response carries no usable data for it.
+//
+// Zero priced priority fees are excluded, even though some networks allow them, because eth_feeHistory returns
+// 0 values for empty blocks and discarding them yields a more representative sample.
+func calcPriorityFees(rewards [][]*big.Int) (avg *assets.Wei, threshold *assets.Wei) {
+	var nonZeroRewardsLen int64
+	priorityFeeSum := big.NewInt(0)
+	priorityFeeThreshold := big.NewInt(0)
+	for _, reward := range rewards {
+		// reward needs to have values for two percentiles. Some chains may return an empty slice instead of 0x0 values, so we
+		// skip it instead of throwing an error.
+		if len(reward) < 2 || reward[0] == nil || reward[1] == nil {
+			continue
+		}
+		// We'll calculate the average of non-zero priority fees
+		if reward[0].Sign() > 0 {
+			priorityFeeSum.Add(priorityFeeSum, reward[0])
+			nonZeroRewardsLen++
+		}
+		// We take the max value for the bumping threshold
+		if reward[1].Sign() > 0 {
+			priorityFeeThreshold = bigmath.Max(priorityFeeThreshold, reward[1])
+		}
 	}
-	return f.dynamicPrice, nil
+
+	if nonZeroRewardsLen > 0 {
+		avg = assets.NewWei(priorityFeeSum.Div(priorityFeeSum, big.NewInt(nonZeroRewardsLen)))
+	}
+	if priorityFeeThreshold.Sign() > 0 {
+		threshold = assets.NewWei(priorityFeeThreshold)
+	}
+	return avg, threshold
+}
+
+// baseFeeBufferPercentage returns the safety buffer applied on top of the latest base fee. BlockHistorySize of 0 is used
+// as the signal for a chain without a mempool, which is the only signal the estimator has for it.
+func (f *FeeHistoryEstimator) baseFeeBufferPercentage() uint16 {
+	if f.config.BlockHistorySize == 0 {
+		return NoMempoolBaseFeeBufferPercentage
+	}
+	return BaseFeeBufferPercentage
+}
+
+func (f *FeeHistoryEstimator) getDynamicFeeCache() dynamicFeeCache {
+	f.dynamicMu.RLock()
+	defer f.dynamicMu.RUnlock()
+	return f.dynamicFeeCache
 }
 
 // BumpLegacyGas provides a bumped gas price value by bumping the previous one by BumpPercent.
@@ -359,20 +419,15 @@ func (f *FeeHistoryEstimator) BumpLegacyGas(ctx context.Context, originalGasPric
 // Both maxFeePerGas as well as maxPriorityFeePerGas need to be bumped otherwise the RPC won't accept the transaction and throw an error.
 // See: https://github.com/ethereum/go-ethereum/issues/24284
 // It aggregates the market, bumped, and max price to provide a correct value, for both maxFeePerGas as well as maxPriorityFerPergas.
+//
+// If BlockHistorySize is 0 the chain has no mempool, so there is no concept of gas bumping and no priority fee to bump: the
+// originalFee is ignored and the freshly refreshed market fee is returned instead.
 func (f *FeeHistoryEstimator) BumpDynamicFee(ctx context.Context, originalFee DynamicFee, maxPrice *assets.Wei, _ []EvmPriorAttempt) (bumped DynamicFee, err error) {
-	// For chains that don't have a mempool there is no concept of gas bumping so we force-call RefreshDynamicPrice to update the underlying base fee value
 	if f.config.BlockHistorySize == 0 {
-		if !f.IfStarted(func() {
-			if refreshErr := f.RefreshDynamicPrice(); refreshErr != nil {
-				err = refreshErr
-				return
-			}
-			f.signalNonBlockingRefresh()
-			bumped, err = f.GetDynamicFee(ctx, maxPrice)
-		}) {
-			return bumped, errors.New("estimator not started")
+		if err = f.refreshDynamicFeeNow(); err != nil {
+			return bumped, err
 		}
-		return bumped, err
+		return f.GetDynamicFee(ctx, maxPrice)
 	}
 
 	// Sanitize original fee input
@@ -385,7 +440,8 @@ func (f *FeeHistoryEstimator) BumpDynamicFee(ctx context.Context, originalFee Dy
 			fees.ErrBump, originalFee.GasFeeCap, originalFee.GasTipCap, maxPrice)
 	}
 
-	currentDynamicPrice, err := f.getDynamicPrice()
+	cache := f.getDynamicFeeCache()
+	currentDynamicFee, err := cache.getDynamicFee()
 	if err != nil {
 		return
 	}
@@ -393,14 +449,14 @@ func (f *FeeHistoryEstimator) BumpDynamicFee(ctx context.Context, originalFee Dy
 	bumpedMaxPriorityFeePerGas := originalFee.GasTipCap.AddPercentage(f.config.BumpPercent)
 	bumpedMaxFeePerGas := originalFee.GasFeeCap.AddPercentage(f.config.BumpPercent)
 
-	bumpedMaxPriorityFeePerGas, err = LimitBumpedFee(originalFee.GasTipCap, currentDynamicPrice.GasTipCap, bumpedMaxPriorityFeePerGas, maxPrice)
+	bumpedMaxPriorityFeePerGas, err = LimitBumpedFee(originalFee.GasTipCap, currentDynamicFee.GasTipCap, bumpedMaxPriorityFeePerGas, maxPrice)
 	if err != nil {
 		return bumped, fmt.Errorf("failed to limit maxPriorityFeePerGas: %w", err)
 	}
 
-	priorityFeeThreshold, e := f.getPriorityFeeThreshold()
-	if e != nil {
-		return bumped, e
+	priorityFeeThreshold, err := cache.getPriorityFeeThreshold()
+	if err != nil {
+		return bumped, err
 	}
 
 	if bumpedMaxPriorityFeePerGas.Cmp(priorityFeeThreshold) > 0 {
@@ -408,13 +464,13 @@ func (f *FeeHistoryEstimator) BumpDynamicFee(ctx context.Context, originalFee Dy
 			fees.ErrConnectivity, bumpedMaxPriorityFeePerGas, strconv.Itoa(ConnectivityPercentile), priorityFeeThreshold)
 	}
 
-	bumpedMaxFeePerGas, err = LimitBumpedFee(originalFee.GasFeeCap, currentDynamicPrice.GasFeeCap, bumpedMaxFeePerGas, maxPrice)
+	bumpedMaxFeePerGas, err = LimitBumpedFee(originalFee.GasFeeCap, currentDynamicFee.GasFeeCap, bumpedMaxFeePerGas, maxPrice)
 	if err != nil {
 		return bumped, fmt.Errorf("failed to limit maxFeePerGas: %w", err)
 	}
 
 	bumpedFee := DynamicFee{GasFeeCap: bumpedMaxFeePerGas, GasTipCap: bumpedMaxPriorityFeePerGas}
-	f.logger.Debugw("bumped dynamic fee", "originalFee", originalFee, "marketFee", currentDynamicPrice, "bumpedFee", bumpedFee)
+	f.logger.Debugw("bumped dynamic fee", "originalFee", originalFee, "marketFee", currentDynamicFee, "bumpedFee", bumpedFee)
 
 	return bumpedFee, nil
 }
@@ -444,24 +500,21 @@ func LimitBumpedFee(originalFee *assets.Wei, currentFee *assets.Wei, bumpedFee *
 	return bumpedFee, nil
 }
 
-func (f *FeeHistoryEstimator) getPriorityFeeThreshold() (*assets.Wei, error) {
-	f.priorityFeeThresholdMu.RLock()
-	defer f.priorityFeeThresholdMu.RUnlock()
-	if f.priorityFeeThreshold == nil {
-		return f.priorityFeeThreshold, errors.New("priorityFeeThreshold not set")
+// refreshDynamicFeeNow refreshes the cached dynamic fees synchronously and pushes the next scheduled refresh back,
+// so the run loop doesn't immediately repeat the call we just made.
+func (f *FeeHistoryEstimator) refreshDynamicFeeNow() error {
+	var err error
+	if !f.IfStarted(func() {
+		if err = f.RefreshDynamicFee(); err == nil {
+			f.signalNonBlockingRefresh()
+		}
+	}) {
+		return errors.New("estimator not started")
 	}
-	return f.priorityFeeThreshold, nil
+	return err
 }
 
-func (f *FeeHistoryEstimator) getNextBaseFee() (*assets.Wei, error) {
-	f.nextBaseFeeMu.RLock()
-	defer f.nextBaseFeeMu.RUnlock()
-	if f.nextBaseFee == nil {
-		return f.nextBaseFee, errors.New("nextBaseFee not set")
-	}
-	return f.nextBaseFee, nil
-}
-
+// signalNonBlockingRefresh resets the run loop's ticker without blocking, deferring the next periodic refresh.
 func (f *FeeHistoryEstimator) signalNonBlockingRefresh() {
 	select {
 	case f.refreshCh <- struct{}{}:

--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -26,7 +26,7 @@ const (
 	MinimumBumpPercentage   = 10 // based on geth's spec
 	ConnectivityPercentile  = 85
 	BaseFeeBufferPercentage = 40
-	MinimumCacheTimeout     = 250 * time.Millisecond
+	MinimumCacheTimeout     = 500 * time.Millisecond
 )
 
 type FeeHistoryEstimatorConfig struct {

--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -268,7 +268,7 @@ func (f *FeeHistoryEstimator) RefreshDynamicPrice() error {
 		for _, reward := range feeHistory.Reward {
 			// reward needs to have values for two percentiles. Some chains may return an empty slice instead of 0x0 values, so we use
 			// continue instead of throwing an error.
-			if len(reward) < 2 {
+			if len(reward) < 2 || reward[0] == nil || reward[1] == nil {
 				continue
 			}
 			// We'll calculate the average of non-zero priority fees

--- a/pkg/gas/fee_history_estimator.go
+++ b/pkg/gas/fee_history_estimator.go
@@ -82,7 +82,7 @@ func NewFeeHistoryEstimator(lggr logger.Logger, client feeHistoryEstimatorClient
 		metrics:   newFeeHistoryEstimatorMetrics(l, chainID),
 		wg:        new(sync.WaitGroup),
 		stopCh:    make(chan struct{}),
-		refreshCh: make(chan struct{}),
+		refreshCh: make(chan struct{}, 1),
 	}
 }
 
@@ -336,7 +336,7 @@ func (f *FeeHistoryEstimator) BumpLegacyGas(ctx context.Context, originalGasPric
 	if err != nil {
 		return nil, 0, err
 	}
-	f.IfStarted(func() { f.refreshCh <- struct{}{} })
+	f.IfStarted(func() { f.signalNonBlockingRefresh() })
 
 	bumpedGasPrice := originalGasPrice.AddPercentage(f.config.BumpPercent)
 	bumpedGasPrice, err = LimitBumpedFee(originalGasPrice, currentGasPrice, bumpedGasPrice, maxPrice)
@@ -363,7 +363,7 @@ func (f *FeeHistoryEstimator) BumpDynamicFee(ctx context.Context, originalFee Dy
 				err = refreshErr
 				return
 			}
-			f.refreshCh <- struct{}{}
+			f.signalNonBlockingRefresh()
 			bumped, err = f.GetDynamicFee(ctx, maxPrice)
 		}) {
 			return bumped, errors.New("estimator not started")
@@ -456,6 +456,13 @@ func (f *FeeHistoryEstimator) getNextBaseFee() (*assets.Wei, error) {
 		return f.nextBaseFee, errors.New("nextBaseFee not set")
 	}
 	return f.nextBaseFee, nil
+}
+
+func (f *FeeHistoryEstimator) signalNonBlockingRefresh() {
+	select {
+	case f.refreshCh <- struct{}{}:
+	default:
+	}
 }
 
 func (f *FeeHistoryEstimator) Name() string                                      { return f.logger.Name() }

--- a/pkg/gas/fee_history_estimator_test.go
+++ b/pkg/gas/fee_history_estimator_test.go
@@ -304,7 +304,7 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		assert.Equal(t, maxPrice, dynamicFee.GasTipCap)
 	})
 
-	t.Run("applies the wider staleness buffer when there is no mempool", func(t *testing.T) {
+	t.Run("applies the NoMempoolBaseFeeBufferPercentage when there is no mempool", func(t *testing.T) {
 		client := mocks.NewFeeHistoryEstimatorClient(t)
 		baseFee := big.NewInt(100)
 		maxPrice := assets.NewWeiI(1000)
@@ -316,8 +316,7 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		}
 		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
 
-		// BlockHistorySize of 0 signals a chain without a mempool, where the buffer covers cache staleness
-		// rather than time to inclusion, so it is wider than the default one.
+		// BlockHistorySize of 0 signals a chain without a mempool, so buffer is increased.
 		cfg := gas.FeeHistoryEstimatorConfig{BlockHistorySize: 0, EIP1559: true}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
@@ -330,7 +329,6 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		assert.Positive(t, dynamicFee.GasFeeCap.Cmp(assets.NewWei(baseFee).AddPercentage(gas.BaseFeeBufferPercentage)),
 			"the no-mempool buffer must be wider than the default one")
 
-		// GetMaxDynamicFee has no priority ladder to climb here, so it agrees with the market fee.
 		maxFee, err := u.GetMaxDynamicFee(maxPrice)
 		require.NoError(t, err)
 		assert.Equal(t, dynamicFee.GasFeeCap, maxFee.GasFeeCap)

--- a/pkg/gas/fee_history_estimator_test.go
+++ b/pkg/gas/fee_history_estimator_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services/servicetest"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink-evm/pkg/assets"
 	"github.com/smartcontractkit/chainlink-evm/pkg/gas"
@@ -35,7 +34,7 @@ func TestFeeHistoryEstimatorLifecycle(t *testing.T) {
 		}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), nil, cfg, chainID, nil)
-		_, _, err := u.GetLegacyGas(tests.Context(t), nil, gasLimit, maxPrice)
+		_, _, err := u.GetLegacyGas(t.Context(), nil, gasLimit, maxPrice)
 		assert.ErrorContains(t, err, "gas price not set")
 	})
 
@@ -43,7 +42,7 @@ func TestFeeHistoryEstimatorLifecycle(t *testing.T) {
 		cfg := gas.FeeHistoryEstimatorConfig{BumpPercent: 9}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), nil, cfg, chainID, nil)
-		assert.ErrorContains(t, u.Start(tests.Context(t)), "BumpPercent")
+		assert.ErrorContains(t, u.Start(t.Context()), "BumpPercent")
 	})
 
 	t.Run("fails to start if RewardPercentile is higher than ConnectivityPercentile in EIP-1559", func(t *testing.T) {
@@ -54,7 +53,18 @@ func TestFeeHistoryEstimatorLifecycle(t *testing.T) {
 		}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), nil, cfg, chainID, nil)
-		assert.ErrorContains(t, u.Start(tests.Context(t)), "RewardPercentile")
+		assert.ErrorContains(t, u.Start(t.Context()), "RewardPercentile")
+	})
+
+	t.Run("fails to start if CacheTimeout is not more than 0", func(t *testing.T) {
+		cfg := gas.FeeHistoryEstimatorConfig{
+			BumpPercent:      20,
+			RewardPercentile: 10,
+			CacheTimeout:     200 * time.Millisecond,
+		}
+
+		u := gas.NewFeeHistoryEstimator(logger.Test(t), nil, cfg, chainID, nil)
+		assert.ErrorContains(t, u.Start(t.Context()), "CacheTimeout")
 	})
 
 	t.Run("starts if configs are correct", func(t *testing.T) {
@@ -68,7 +78,7 @@ func TestFeeHistoryEstimatorLifecycle(t *testing.T) {
 		}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		err := u.Start(tests.Context(t))
+		err := u.Start(t.Context())
 		assert.NoError(t, err)
 		err = u.Close()
 		assert.NoError(t, err)
@@ -91,7 +101,7 @@ func TestFeeHistoryEstimatorGetLegacyGas(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		_, err := u.RefreshGasPrice()
 		assert.NoError(t, err)
-		gasPrice, _, err := u.GetLegacyGas(tests.Context(t), nil, gasLimit, maxPrice)
+		gasPrice, _, err := u.GetLegacyGas(t.Context(), nil, gasLimit, maxPrice)
 		assert.NoError(t, err)
 		assert.Equal(t, assets.NewWeiI(10), gasPrice)
 	})
@@ -106,7 +116,7 @@ func TestFeeHistoryEstimatorGetLegacyGas(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		_, err := u.RefreshGasPrice()
 		assert.NoError(t, err)
-		gas1, _, err := u.GetLegacyGas(tests.Context(t), nil, gasLimit, maxPrice)
+		gas1, _, err := u.GetLegacyGas(t.Context(), nil, gasLimit, maxPrice)
 		assert.NoError(t, err)
 		assert.Equal(t, maxPrice, gas1)
 	})
@@ -116,7 +126,7 @@ func TestFeeHistoryEstimatorGetLegacyGas(t *testing.T) {
 
 		maxPrice := assets.NewWeiI(1)
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), nil, cfg, chainID, nil)
-		_, _, err := u.GetLegacyGas(tests.Context(t), nil, gasLimit, maxPrice)
+		_, _, err := u.GetLegacyGas(t.Context(), nil, gasLimit, maxPrice)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "gas price not set")
 	})
@@ -138,7 +148,7 @@ func TestFeeHistoryEstimatorBumpLegacyGas(t *testing.T) {
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		servicetest.RunHealthy(t, u)
-		gasPrice, _, err := u.BumpLegacyGas(tests.Context(t), originalGasPrice, gasLimit, maxPrice, nil)
+		gasPrice, _, err := u.BumpLegacyGas(t.Context(), originalGasPrice, gasLimit, maxPrice, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, assets.NewWeiI(15), gasPrice)
 	})
@@ -150,11 +160,11 @@ func TestFeeHistoryEstimatorBumpLegacyGas(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 
 		var originalPrice *assets.Wei
-		_, _, err := u.BumpLegacyGas(tests.Context(t), originalPrice, gasLimit, maxPrice, nil)
+		_, _, err := u.BumpLegacyGas(t.Context(), originalPrice, gasLimit, maxPrice, nil)
 		assert.Error(t, err)
 
 		originalPrice = assets.NewWeiI(100)
-		_, _, err = u.BumpLegacyGas(tests.Context(t), originalPrice, gasLimit, maxPrice, nil)
+		_, _, err = u.BumpLegacyGas(t.Context(), originalPrice, gasLimit, maxPrice, nil)
 		assert.Error(t, err)
 	})
 
@@ -166,7 +176,7 @@ func TestFeeHistoryEstimatorBumpLegacyGas(t *testing.T) {
 		cfg := gas.FeeHistoryEstimatorConfig{}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		gas, _, err := u.BumpLegacyGas(tests.Context(t), originalGasPrice, gasLimit, maxPrice, nil)
+		gas, _, err := u.BumpLegacyGas(t.Context(), originalGasPrice, gasLimit, maxPrice, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, assets.NewWeiI(80), gas)
 	})
@@ -180,7 +190,7 @@ func TestFeeHistoryEstimatorBumpLegacyGas(t *testing.T) {
 
 		maxPrice := assets.NewWeiI(14)
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		gas, _, err := u.BumpLegacyGas(tests.Context(t), originalGasPrice, gasLimit, maxPrice, nil)
+		gas, _, err := u.BumpLegacyGas(t.Context(), originalGasPrice, gasLimit, maxPrice, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, maxPrice, gas)
 	})
@@ -194,7 +204,7 @@ func TestFeeHistoryEstimatorBumpLegacyGas(t *testing.T) {
 
 		maxPrice := assets.NewWeiI(14)
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		gas, _, err := u.BumpLegacyGas(tests.Context(t), originalGasPrice, gasLimit, maxPrice, nil)
+		gas, _, err := u.BumpLegacyGas(t.Context(), originalGasPrice, gasLimit, maxPrice, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, maxPrice, gas)
 	})
@@ -209,7 +219,7 @@ func TestFeeHistoryEstimatorBumpLegacyGas(t *testing.T) {
 		// Price will be capped by the max price
 		maxPrice := assets.NewWeiI(101)
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		_, _, err := u.BumpLegacyGas(tests.Context(t), originalGasPrice, gasLimit, maxPrice, nil)
+		_, _, err := u.BumpLegacyGas(t.Context(), originalGasPrice, gasLimit, maxPrice, nil)
 		assert.Error(t, err)
 	})
 }
@@ -243,7 +253,7 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		err := u.RefreshDynamicPrice()
 		assert.NoError(t, err)
-		dynamicFee, err := u.GetDynamicFee(tests.Context(t), maxPrice)
+		dynamicFee, err := u.GetDynamicFee(t.Context(), maxPrice)
 		assert.NoError(t, err)
 		assert.Equal(t, maxFee, dynamicFee.GasFeeCap)
 		assert.Equal(t, (*assets.Wei)(avrgPriorityFee), dynamicFee.GasTipCap)
@@ -254,7 +264,7 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 
 		maxPrice := assets.NewWeiI(1)
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), nil, cfg, chainID, nil)
-		_, err := u.GetDynamicFee(tests.Context(t), maxPrice)
+		_, err := u.GetDynamicFee(t.Context(), maxPrice)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "dynamic price not set")
 	})
@@ -278,7 +288,7 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		err := u.RefreshDynamicPrice()
 		assert.NoError(t, err)
-		dynamicFee, err := u.GetDynamicFee(tests.Context(t), maxPrice)
+		dynamicFee, err := u.GetDynamicFee(t.Context(), maxPrice)
 		assert.NoError(t, err)
 		assert.Equal(t, maxPrice, dynamicFee.GasFeeCap)
 		assert.Equal(t, maxPrice, dynamicFee.GasTipCap)
@@ -374,7 +384,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		err := u.RefreshDynamicPrice()
 		assert.NoError(t, err)
-		dynamicFee, err := u.BumpDynamicFee(tests.Context(t), originalFee, globalMaxPrice, nil)
+		dynamicFee, err := u.BumpDynamicFee(t.Context(), originalFee, globalMaxPrice, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedFeeCap, dynamicFee.GasFeeCap)
 		assert.Equal(t, expectedTipCap, dynamicFee.GasTipCap)
@@ -388,7 +398,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		// nil original fee
 		var originalFee gas.DynamicFee
-		_, err := u.BumpDynamicFee(tests.Context(t), originalFee, maxPrice, nil)
+		_, err := u.BumpDynamicFee(t.Context(), originalFee, maxPrice, nil)
 		assert.Error(t, err)
 
 		// tip cap is higher than fee cap
@@ -396,7 +406,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 			GasFeeCap: assets.NewWeiI(10),
 			GasTipCap: assets.NewWeiI(11),
 		}
-		_, err = u.BumpDynamicFee(tests.Context(t), originalFee, maxPrice, nil)
+		_, err = u.BumpDynamicFee(t.Context(), originalFee, maxPrice, nil)
 		assert.Error(t, err)
 
 		// fee cap is equal or higher to max price
@@ -404,7 +414,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 			GasFeeCap: assets.NewWeiI(20),
 			GasTipCap: assets.NewWeiI(10),
 		}
-		_, err = u.BumpDynamicFee(tests.Context(t), originalFee, maxPrice, nil)
+		_, err = u.BumpDynamicFee(t.Context(), originalFee, maxPrice, nil)
 		assert.Error(t, err)
 	})
 
@@ -436,7 +446,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		err := u.RefreshDynamicPrice()
 		assert.NoError(t, err)
-		bumpedFee, err := u.BumpDynamicFee(tests.Context(t), originalFee, globalMaxPrice, nil)
+		bumpedFee, err := u.BumpDynamicFee(t.Context(), originalFee, globalMaxPrice, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, (*assets.Wei)(maxPriorityFeePerGas), bumpedFee.GasTipCap)
 		assert.Equal(t, maxFee, bumpedFee.GasFeeCap)
@@ -468,7 +478,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		err := u.RefreshDynamicPrice()
 		assert.NoError(t, err)
-		_, err = u.BumpDynamicFee(tests.Context(t), originalFee, globalMaxPrice, nil)
+		_, err = u.BumpDynamicFee(t.Context(), originalFee, globalMaxPrice, nil)
 		assert.Error(t, err)
 		assert.True(t, fees.IsBumpErr(err))
 	})
@@ -500,7 +510,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		err := u.RefreshDynamicPrice()
 		assert.NoError(t, err)
-		bumpedFee, err := u.BumpDynamicFee(tests.Context(t), originalFee, maxPrice, nil)
+		bumpedFee, err := u.BumpDynamicFee(t.Context(), originalFee, maxPrice, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, maxPrice, bumpedFee.GasTipCap)
 		assert.Equal(t, maxPrice, bumpedFee.GasFeeCap)
@@ -533,7 +543,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		err := u.RefreshDynamicPrice()
 		assert.NoError(t, err)
-		_, err = u.BumpDynamicFee(tests.Context(t), originalFee, maxPrice, nil)
+		_, err = u.BumpDynamicFee(t.Context(), originalFee, maxPrice, nil)
 		assert.Error(t, err)
 	})
 
@@ -565,7 +575,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		maxFeePerGas := assets.NewWei(baseFee).AddPercentage(gas.BaseFeeBufferPercentage)
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		servicetest.RunHealthy(t, u)
-		bumpedFee, err := u.BumpDynamicFee(tests.Context(t), originalFee, globalMaxPrice, nil)
+		bumpedFee, err := u.BumpDynamicFee(t.Context(), originalFee, globalMaxPrice, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, (*assets.Wei)(maxPriorityFeePerGas), assets.NewWeiI(0))
 		assert.Equal(t, maxFeePerGas, bumpedFee.GasFeeCap)

--- a/pkg/gas/fee_history_estimator_test.go
+++ b/pkg/gas/fee_history_estimator_test.go
@@ -56,7 +56,7 @@ func TestFeeHistoryEstimatorLifecycle(t *testing.T) {
 		assert.ErrorContains(t, u.Start(t.Context()), "RewardPercentile")
 	})
 
-	t.Run("fails to start if CacheTimeout is not more than 0", func(t *testing.T) {
+	t.Run("fails to start if CacheTimeout is not more than MinimumCacheTimeout", func(t *testing.T) {
 		cfg := gas.FeeHistoryEstimatorConfig{
 			BumpPercent:      20,
 			RewardPercentile: 10,

--- a/pkg/gas/fee_history_estimator_test.go
+++ b/pkg/gas/fee_history_estimator_test.go
@@ -56,7 +56,7 @@ func TestFeeHistoryEstimatorLifecycle(t *testing.T) {
 		assert.ErrorContains(t, u.Start(t.Context()), "RewardPercentile")
 	})
 
-	t.Run("fails to start if CacheTimeout is not more than MinimumCacheTimeout", func(t *testing.T) {
+	t.Run("fails to start if CacheTimeout is less than MinimumCacheTimeout", func(t *testing.T) {
 		cfg := gas.FeeHistoryEstimatorConfig{
 			BumpPercent:      20,
 			RewardPercentile: 10,
@@ -236,9 +236,18 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		maxPriorityFeePerGas1 := big.NewInt(33)
 		maxPriorityFeePerGas2 := big.NewInt(20)
 
+		// first one represents market price and second one connectivity price
+		// empty and nil entries are skipped
+		reward := [][]*big.Int{
+			{maxPriorityFeePerGas1, big.NewInt(5)},
+			{maxPriorityFeePerGas2, big.NewInt(5)},
+			{},
+			{nil, big.NewInt(5)},
+			{big.NewInt(5), nil},
+		}
 		feeHistoryResult := &ethereum.FeeHistory{
 			OldestBlock:  big.NewInt(1),
-			Reward:       [][]*big.Int{{maxPriorityFeePerGas1, big.NewInt(5)}, {maxPriorityFeePerGas2, big.NewInt(5)}, {}}, // first one represents market price and second one connectivity price
+			Reward:       reward,
 			BaseFee:      []*big.Int{baseFee, baseFee},
 			GasUsedRatio: nil,
 		}

--- a/pkg/gas/fee_history_estimator_test.go
+++ b/pkg/gas/fee_history_estimator_test.go
@@ -1,6 +1,7 @@
 package gas_test
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -260,7 +261,7 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		maxFee := (*assets.Wei)(baseFee).AddPercentage(gas.BaseFeeBufferPercentage).Add((*assets.Wei)(avrgPriorityFee))
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		err := u.RefreshDynamicPrice()
+		err := u.RefreshDynamicFee()
 		assert.NoError(t, err)
 		dynamicFee, err := u.GetDynamicFee(t.Context(), maxPrice)
 		assert.NoError(t, err)
@@ -268,14 +269,14 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		assert.Equal(t, (*assets.Wei)(avrgPriorityFee), dynamicFee.GasTipCap)
 	})
 
-	t.Run("fails if dynamic prices have not been set yet", func(t *testing.T) {
+	t.Run("fails if dynamic fee has not been set yet", func(t *testing.T) {
 		cfg := gas.FeeHistoryEstimatorConfig{}
 
 		maxPrice := assets.NewWeiI(1)
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), nil, cfg, chainID, nil)
 		_, err := u.GetDynamicFee(t.Context(), maxPrice)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "dynamic price not set")
+		assert.ErrorContains(t, err, "dynamic fee not set")
 	})
 
 	t.Run("will return max price if tip cap or fee cap exceed it", func(t *testing.T) {
@@ -295,12 +296,44 @@ func TestFeeHistoryEstimatorGetDynamicFee(t *testing.T) {
 		cfg := gas.FeeHistoryEstimatorConfig{BlockHistorySize: 1}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		err := u.RefreshDynamicPrice()
+		err := u.RefreshDynamicFee()
 		assert.NoError(t, err)
 		dynamicFee, err := u.GetDynamicFee(t.Context(), maxPrice)
 		assert.NoError(t, err)
 		assert.Equal(t, maxPrice, dynamicFee.GasFeeCap)
 		assert.Equal(t, maxPrice, dynamicFee.GasTipCap)
+	})
+
+	t.Run("applies the wider staleness buffer when there is no mempool", func(t *testing.T) {
+		client := mocks.NewFeeHistoryEstimatorClient(t)
+		baseFee := big.NewInt(100)
+		maxPrice := assets.NewWeiI(1000)
+
+		feeHistoryResult := &ethereum.FeeHistory{
+			OldestBlock: big.NewInt(1),
+			Reward:      [][]*big.Int{{big.NewInt(0), big.NewInt(0)}},
+			BaseFee:     []*big.Int{baseFee},
+		}
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(feeHistoryResult, nil).Once()
+
+		// BlockHistorySize of 0 signals a chain without a mempool, where the buffer covers cache staleness
+		// rather than time to inclusion, so it is wider than the default one.
+		cfg := gas.FeeHistoryEstimatorConfig{BlockHistorySize: 0, EIP1559: true}
+
+		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
+		require.NoError(t, u.RefreshDynamicFee())
+
+		dynamicFee, err := u.GetDynamicFee(t.Context(), maxPrice)
+		require.NoError(t, err)
+		assert.Equal(t, assets.NewWei(baseFee).AddPercentage(gas.NoMempoolBaseFeeBufferPercentage), dynamicFee.GasFeeCap)
+		assert.Equal(t, assets.NewWeiI(0), dynamicFee.GasTipCap)
+		assert.Positive(t, dynamicFee.GasFeeCap.Cmp(assets.NewWei(baseFee).AddPercentage(gas.BaseFeeBufferPercentage)),
+			"the no-mempool buffer must be wider than the default one")
+
+		// GetMaxDynamicFee has no priority ladder to climb here, so it agrees with the market fee.
+		maxFee, err := u.GetMaxDynamicFee(maxPrice)
+		require.NoError(t, err)
+		assert.Equal(t, dynamicFee.GasFeeCap, maxFee.GasFeeCap)
 	})
 }
 
@@ -346,7 +379,7 @@ func TestFeeHistoryEstimatorGetMaxDynamicFee(t *testing.T) {
 		}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		err := u.RefreshDynamicPrice()
+		err := u.RefreshDynamicFee()
 		require.NoError(t, err)
 
 		expectedPriorityFeeThreshold := assets.NewWei(connectivityMaxPriorityFeePerGas)
@@ -357,6 +390,125 @@ func TestFeeHistoryEstimatorGetMaxDynamicFee(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expectedMaxFeeCap, fee.GasFeeCap)
 		assert.Equal(t, expectedPriorityFeeThreshold, fee.GasTipCap)
+	})
+
+	t.Run("caches the next base fee even when the rewards are all zero", func(t *testing.T) {
+		client := mocks.NewFeeHistoryEstimatorClient(t)
+		baseFee := big.NewInt(5)
+		zero := big.NewInt(0)
+		marketMaxPriorityFeePerGas := big.NewInt(10)
+		connectivityMaxPriorityFeePerGas := big.NewInt(20)
+
+		// First round returns no usable priority fees, so only the base fee can be cached.
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ethereum.FeeHistory{
+			OldestBlock: big.NewInt(1),
+			Reward:      [][]*big.Int{{zero, zero}, {}},
+			BaseFee:     []*big.Int{baseFee, baseFee},
+		}, nil).Once()
+		// Second round returns no base fee at all, which must fall back to the one cached above.
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ethereum.FeeHistory{
+			OldestBlock: big.NewInt(2),
+			Reward:      [][]*big.Int{{marketMaxPriorityFeePerGas, connectivityMaxPriorityFeePerGas}},
+			BaseFee:     []*big.Int{},
+		}, nil).Once()
+
+		cfg := gas.FeeHistoryEstimatorConfig{
+			BumpPercent:      20,
+			RewardPercentile: 60,
+			EIP1559:          true,
+			BlockHistorySize: 2,
+		}
+
+		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
+		require.NoError(t, u.RefreshDynamicFee())
+		// The priority fees are still unset, but the base fee has been cached.
+		_, err := u.GetMaxDynamicFee(maxPrice)
+		require.ErrorContains(t, err, "priorityFeeThreshold not set")
+
+		require.NoError(t, u.RefreshDynamicFee())
+		expectedPriorityFeeThreshold := assets.NewWei(connectivityMaxPriorityFeePerGas)
+		expectedMaxFeeCap := assets.NewWei(baseFee).AddPercentage(gas.BaseFeeBufferPercentage).Add(expectedPriorityFeeThreshold)
+
+		fee, err := u.GetMaxDynamicFee(maxPrice)
+		require.NoError(t, err)
+		assert.Equal(t, expectedMaxFeeCap, fee.GasFeeCap)
+		assert.Equal(t, expectedPriorityFeeThreshold, fee.GasTipCap)
+	})
+
+	t.Run("keeps the cached priority fees as a pair when a round has no usable average", func(t *testing.T) {
+		client := mocks.NewFeeHistoryEstimatorClient(t)
+		maxPrice := assets.NewWeiI(1000)
+
+		// First round is busy: both the average and the connectivity threshold are usable.
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ethereum.FeeHistory{
+			OldestBlock: big.NewInt(1),
+			Reward:      [][]*big.Int{{big.NewInt(100), big.NewInt(200)}},
+			BaseFee:     []*big.Int{big.NewInt(10), big.NewInt(10)},
+		}, nil).Once()
+		// Second round is quiet: the RewardPercentile fee is 0 so no average can be derived, while the
+		// ConnectivityPercentile one drops to 50. Applying only the latter would leave the cache with
+		// maxPriorityFeePerGas(100) > priorityFeeThreshold(50) and halt bumping with a bogus ErrConnectivity.
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ethereum.FeeHistory{
+			OldestBlock: big.NewInt(2),
+			Reward:      [][]*big.Int{{big.NewInt(0), big.NewInt(50)}},
+			BaseFee:     []*big.Int{big.NewInt(20), big.NewInt(20)},
+		}, nil).Once()
+
+		cfg := gas.FeeHistoryEstimatorConfig{
+			BumpPercent:      20,
+			RewardPercentile: 60,
+			EIP1559:          true,
+			BlockHistorySize: 2,
+		}
+
+		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
+		require.NoError(t, u.RefreshDynamicFee())
+		require.NoError(t, u.RefreshDynamicFee())
+
+		// Both priority fees are retained from the first round, so the invariant still holds.
+		fee, err := u.GetDynamicFee(t.Context(), maxPrice)
+		require.NoError(t, err)
+		assert.Equal(t, assets.NewWeiI(100), fee.GasTipCap)
+		// The fee cap still tracked the second round's base fee: 20 * 1.4 + 100.
+		assert.Equal(t, assets.NewWeiI(128), fee.GasFeeCap)
+
+		maxFee, err := u.GetMaxDynamicFee(maxPrice)
+		require.NoError(t, err)
+		assert.Equal(t, assets.NewWeiI(200), maxFee.GasTipCap)
+		assert.GreaterOrEqual(t, maxFee.GasTipCap.Cmp(fee.GasTipCap), 0, "the max tip cap must never fall below the market one")
+	})
+
+	t.Run("raises the threshold when the RPC returns non-monotonic percentiles", func(t *testing.T) {
+		client := mocks.NewFeeHistoryEstimatorClient(t)
+		maxPrice := assets.NewWeiI(1000)
+
+		// ConnectivityPercentile(50) below RewardPercentile(100) is impossible for percentiles of the same
+		// sample, so the threshold is raised to the average instead of halting every bump.
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ethereum.FeeHistory{
+			OldestBlock: big.NewInt(1),
+			Reward:      [][]*big.Int{{big.NewInt(100), big.NewInt(50)}},
+			BaseFee:     []*big.Int{big.NewInt(10), big.NewInt(10)},
+		}, nil).Once()
+
+		cfg := gas.FeeHistoryEstimatorConfig{
+			BumpPercent:      20,
+			RewardPercentile: 60,
+			EIP1559:          true,
+			BlockHistorySize: 2,
+		}
+
+		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
+		require.NoError(t, u.RefreshDynamicFee())
+
+		maxFee, err := u.GetMaxDynamicFee(maxPrice)
+		require.NoError(t, err)
+		assert.Equal(t, assets.NewWeiI(100), maxFee.GasTipCap)
+
+		// Bumping up to the market tip is still allowed rather than tripping ErrConnectivity.
+		originalFee := gas.DynamicFee{GasFeeCap: assets.NewWeiI(20), GasTipCap: assets.NewWeiI(10)}
+		bumped, err := u.BumpDynamicFee(t.Context(), originalFee, maxPrice, nil)
+		require.NoError(t, err)
+		assert.Equal(t, assets.NewWeiI(100), bumped.GasTipCap)
 	})
 }
 
@@ -391,7 +543,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		expectedTipCap := originalFee.GasTipCap.AddPercentage(cfg.BumpPercent)
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		err := u.RefreshDynamicPrice()
+		err := u.RefreshDynamicFee()
 		assert.NoError(t, err)
 		dynamicFee, err := u.BumpDynamicFee(t.Context(), originalFee, globalMaxPrice, nil)
 		assert.NoError(t, err)
@@ -453,7 +605,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		err := u.RefreshDynamicPrice()
+		err := u.RefreshDynamicFee()
 		assert.NoError(t, err)
 		bumpedFee, err := u.BumpDynamicFee(t.Context(), originalFee, globalMaxPrice, nil)
 		assert.NoError(t, err)
@@ -463,14 +615,16 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 
 	t.Run("fails if connectivity percentile value is reached", func(t *testing.T) {
 		client := mocks.NewFeeHistoryEstimatorClient(t)
+		// Bumping the original tip cap by BumpPercent lands on 36, above the market's connectivity percentile of 30.
 		originalFee := gas.DynamicFee{
-			GasFeeCap: assets.NewWeiI(20),
-			GasTipCap: assets.NewWeiI(10),
+			GasFeeCap: assets.NewWeiI(40),
+			GasTipCap: assets.NewWeiI(24),
 		}
 
-		// Market fees
+		// Market fees. The two percentiles come from the same sample, so the market price cannot exceed the
+		// connectivity one; the threshold is reached by the bumped attempt, not by the market.
 		baseFee := big.NewInt(5)
-		maxPriorityFeePerGas := big.NewInt(33)
+		maxPriorityFeePerGas := big.NewInt(20)
 		feeHistoryResult := &ethereum.FeeHistory{
 			OldestBlock:  big.NewInt(1),
 			Reward:       [][]*big.Int{{maxPriorityFeePerGas, big.NewInt(30)}}, // first one represents market price and second one connectivity price
@@ -485,11 +639,12 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		err := u.RefreshDynamicPrice()
+		err := u.RefreshDynamicFee()
 		assert.NoError(t, err)
 		_, err = u.BumpDynamicFee(t.Context(), originalFee, globalMaxPrice, nil)
 		assert.Error(t, err)
 		assert.True(t, fees.IsBumpErr(err))
+		assert.ErrorIs(t, err, fees.ErrConnectivity)
 	})
 
 	t.Run("returns max price if the aggregation of max and original bumped fee is higher", func(t *testing.T) {
@@ -517,7 +672,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		err := u.RefreshDynamicPrice()
+		err := u.RefreshDynamicFee()
 		assert.NoError(t, err)
 		bumpedFee, err := u.BumpDynamicFee(t.Context(), originalFee, maxPrice, nil)
 		assert.NoError(t, err)
@@ -550,7 +705,7 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 		}
 
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
-		err := u.RefreshDynamicPrice()
+		err := u.RefreshDynamicFee()
 		assert.NoError(t, err)
 		_, err = u.BumpDynamicFee(t.Context(), originalFee, maxPrice, nil)
 		assert.Error(t, err)
@@ -581,12 +736,44 @@ func TestFeeHistoryEstimatorBumpDynamicFee(t *testing.T) {
 			EIP1559:          true,
 		}
 
-		maxFeePerGas := assets.NewWei(baseFee).AddPercentage(gas.BaseFeeBufferPercentage)
+		// No mempool means the wider staleness buffer applies.
+		maxFeePerGas := assets.NewWei(baseFee).AddPercentage(gas.NoMempoolBaseFeeBufferPercentage)
 		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
 		servicetest.RunHealthy(t, u)
 		bumpedFee, err := u.BumpDynamicFee(t.Context(), originalFee, globalMaxPrice, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, (*assets.Wei)(maxPriorityFeePerGas), assets.NewWeiI(0))
 		assert.Equal(t, maxFeePerGas, bumpedFee.GasFeeCap)
+	})
+
+	t.Run("fails if there is no mempool and the estimator is not started", func(t *testing.T) {
+		cfg := gas.FeeHistoryEstimatorConfig{
+			BlockHistorySize: 0,
+			BumpPercent:      20,
+			CacheTimeout:     10 * time.Second,
+			EIP1559:          true,
+		}
+
+		// The client is never called because the estimator isn't started.
+		u := gas.NewFeeHistoryEstimator(logger.Test(t), mocks.NewFeeHistoryEstimatorClient(t), cfg, chainID, nil)
+		_, err := u.BumpDynamicFee(t.Context(), gas.DynamicFee{GasFeeCap: assets.NewWeiI(40), GasTipCap: assets.NewWeiI(0)}, globalMaxPrice, nil)
+		require.ErrorContains(t, err, "estimator not started")
+	})
+
+	t.Run("propagates the refresh error if there is no mempool", func(t *testing.T) {
+		client := mocks.NewFeeHistoryEstimatorClient(t)
+		client.On("FeeHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("RPC unreachable"))
+
+		cfg := gas.FeeHistoryEstimatorConfig{
+			BlockHistorySize: 0,
+			BumpPercent:      20,
+			CacheTimeout:     10 * time.Second,
+			EIP1559:          true,
+		}
+
+		u := gas.NewFeeHistoryEstimator(logger.Test(t), client, cfg, chainID, nil)
+		servicetest.RunHealthy(t, u)
+		_, err := u.BumpDynamicFee(t.Context(), gas.DynamicFee{GasFeeCap: assets.NewWeiI(40), GasTipCap: assets.NewWeiI(0)}, globalMaxPrice, nil)
+		require.ErrorContains(t, err, "RPC unreachable")
 	})
 }


### PR DESCRIPTION
This PR:
- Checks for nil entries in `feeHistory`'s rewards.
- Adds a minimum `CacheTimeout` check.
- Switches to non-blocking refresh to avoid getting stuck
- Now makes `maxFeePerGas` and `priorityFeeThreshold` updates consistent - prevents `priorityFeeThreshold` being lower than `maxFeePerGas` at a given instance, which can trigger false positive connectivity errors.
- Unifies dynamic fee variables under one dynamic fee cache structure.
- Fixes a bug where base wouldn't update if the maxFeePerGas and priorityFeeThreshold were not available.
- Introduces a `newNoMempoolBaseFeeBufferPercentage` for chains without a mempool i.e. Arbitrum, to prevent insufficient base fee errors.
- Improves structure and name conventions across the board