### PR TITLE
Classify Pharos Invalid Account error as fatal

### DIFF
--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -318,6 +318,10 @@ var cronos = ClientErrors{
 	ServiceUnavailable:          regexp.MustCompile(`eth_sendRawTransaction does not exist/is not available`),
 }
 
+var pharos = ClientErrors{
+	Fatal: regexp.MustCompile(`errcode: 80004, errmsg: INVALID_ACCOUNT_ADDRESS`),
+}
+
 const TerminallyStuckMsg = "transaction terminally stuck"
 
 // Tx.Error messages that are set internally so they are not chain or client specific
@@ -325,7 +329,7 @@ var internal = ClientErrors{
 	TerminallyStuck: regexp.MustCompile(TerminallyStuckMsg),
 }
 
-var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, optimism, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, treasure, mantle, aStar, hedera, gnosis, sei, monad, jovay, cronos, internal}
+var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, optimism, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, treasure, mantle, aStar, hedera, gnosis, sei, monad, jovay, cronos, pharos, internal}
 
 // ClientErrorRegexes returns a map of compiled regexes for each error type
 func ClientErrorRegexes(errsRegex config.ClientErrors) *ClientErrors {

--- a/pkg/client/errors_test.go
+++ b/pkg/client/errors_test.go
@@ -464,6 +464,11 @@ func Test_Eth_Errors_Fatal(t *testing.T) {
 
 		{"Gas limit too low", true, "monad"},
 
+		{"RPC call failed: errcode: 80004, errmsg: INVALID_ACCOUNT_ADDRESS", true, "pharos"},
+		{"errcode: 80004, errmsg: INVALID_ACCOUNT_ADDRESS", true, "pharos"},
+		{"INVALID_ACCOUNT_ADDRESS", false, "pharos"},
+		{"RPC call failed: errcode: 80005, errmsg: INVALID_ACCOUNT_ADDRESS", false, "pharos"},
+
 		{"oversized data: transaction size 138074, limit 131072", true, "Optimism"},
 	}
 


### PR DESCRIPTION
Context: PierTwo stuck retrying this error [Grafana](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22zhi%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22expr%22:%22%7Btenant_id%3D%5C%22ip-beholder-prod-obs-gateway%5C%22%7D%20%7C%20beholder_data_type%20%3D%20%60zap_log_message%60%20%7C%20node_id%20%3D%20%60pier-two-cre-chain-primary-beta-1%60%20%7C%20evmChainID%20%3D%20%601672%60%20%7C~%20%5C%22too%20many%20unstarted%20transactions%20in%20the%20queue%7CProcessUnstartedTxs%7CTransaction%20throttling%7CUnknown%20error%20encountered%20when%20sending%20transaction%7CUnknown%20error%20occurred%20while%20handling%20tx%20queue%7CTxm%23CreateTransaction%7CCheckTxQueueCapacity%5C%22%22,%22queryType%22:%22range%22,%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22direction%22:%22forward%22%7D%5D,%22range%22:%7B%22from%22:%22now-30m%22,%22to%22:%22now%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22sortOrder%22:%22Ascending%22,%22visualisationType%22:%22logs%22,%22displayedFields%22:%5B%22err%22%5D%7D%7D,%22compact%22:false%7D%7D&orgId=1)