### PR TITLE
Fix multiOfaClient secondary send goroutine racing test teardown

### DIFF
--- a/pkg/txm/clientwrappers/dualbroadcast/multiofa_client.go
+++ b/pkg/txm/clientwrappers/dualbroadcast/multiofa_client.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -31,6 +32,12 @@ type multiOfaClient struct {
 	primary              multiOfaBackend
 	secondaries          []multiOfaBackend
 	secondarySendTimeout time.Duration // used in unit tests to configure the timeout
+
+	// secondarySends tracks the in-flight best-effort secondary goroutines, which
+	// outlive the SendTransaction call that spawned them. Waiting on it gives them
+	// an observable lifetime, so callers (notably tests) can join them instead of
+	// racing their teardown.
+	secondarySends sync.WaitGroup
 }
 
 var _ txm.Client = (*multiOfaClient)(nil)
@@ -93,7 +100,10 @@ func (m *multiOfaClient) SendTransaction(ctx context.Context, tx *types.Transact
 	// Secondaries are best-effort and do not block the primary. Each call is bounded by
 	// secondarySendTimeout
 	for _, secondary := range m.secondaries {
+		m.secondarySends.Add(1)
 		go func() {
+			defer m.secondarySends.Done()
+
 			secondaryCtx, cancel := context.WithTimeout(ctx, m.secondarySendTimeout)
 			defer cancel()
 

--- a/pkg/txm/clientwrappers/dualbroadcast/multiofa_client.go
+++ b/pkg/txm/clientwrappers/dualbroadcast/multiofa_client.go
@@ -33,10 +33,8 @@ type multiOfaClient struct {
 	secondaries          []multiOfaBackend
 	secondarySendTimeout time.Duration // used in unit tests to configure the timeout
 
-	// secondarySends tracks the in-flight best-effort secondary goroutines, which
-	// outlive the SendTransaction call that spawned them. Waiting on it gives them
-	// an observable lifetime, so callers (notably tests) can join them instead of
-	// racing their teardown.
+	// secondarySends tracks the in-flight best-effort secondary goroutines.
+	// Only tests call Wait() on them to prevent races during their teardown.
 	secondarySends sync.WaitGroup
 }
 
@@ -100,10 +98,7 @@ func (m *multiOfaClient) SendTransaction(ctx context.Context, tx *types.Transact
 	// Secondaries are best-effort and do not block the primary. Each call is bounded by
 	// secondarySendTimeout
 	for _, secondary := range m.secondaries {
-		m.secondarySends.Add(1)
-		go func() {
-			defer m.secondarySends.Done()
-
+		m.secondarySends.Go(func() {
 			secondaryCtx, cancel := context.WithTimeout(ctx, m.secondarySendTimeout)
 			defer cancel()
 
@@ -114,7 +109,7 @@ func (m *multiOfaClient) SendTransaction(ctx context.Context, tx *types.Transact
 					"attemptHash", attempt.Hash,
 					"transactionLifecycleID", tx.GetTransactionLifecycleID(m.lggr))
 			}
-		}()
+		})
 	}
 
 	primaryCtx, cancel := context.WithTimeout(ctx, rpcTimeout)

--- a/pkg/txm/clientwrappers/dualbroadcast/multiofa_client_test.go
+++ b/pkg/txm/clientwrappers/dualbroadcast/multiofa_client_test.go
@@ -45,13 +45,17 @@ var _ ofaBackendRPCClient = (*chainClientMock)(nil)
 
 func createMultiOfaClient(t *testing.T, c ofaBackendRPCClient, primary multiOfaBackend, secondaries ...multiOfaBackend) *multiOfaClient {
 	t.Helper()
-	return &multiOfaClient{
+	mc := &multiOfaClient{
 		lggr:                 logger.Sugared(logger.Test(t)),
 		chainClient:          c,
 		primary:              primary,
 		secondaries:          secondaries,
 		secondarySendTimeout: rpcTimeout,
 	}
+	// Secondary sends are best-effort and outlive SendTransaction. Join them before
+	// the test completes, otherwise they log into a finished *testing.T and panic.
+	t.Cleanup(mc.secondarySends.Wait)
+	return mc
 }
 
 type ofaBackendMock struct {


### PR DESCRIPTION
multiOfaClient.SendTransaction fans out to secondaries in fire-and-forget goroutines that outlive the call by up to secondarySendTimeout. Nothing could observe them, so on the error path they logged into a *testing.T that had already completed:
```
    panic: Log in goroutine after TestMultiOfaClient_SecondarySendRespectsTimeout
    has completed: ERROR Secondary backend send failed
```

CI surfaced this as a data race rather than the panic, because the race detector saw the cross-test-boundary access first. It has failed at least twice on unrelated branches (runs 32469028488, 34243124630). It is not a true flake: it reproduces on the second iteration of
```
    go test ./pkg/txm/clientwrappers/dualbroadcast/ -race \
      -run 'TestMultiOfaClient_SecondarySendRespectsTimeout$' -count=20
```

and is only hidden in CI because CI runs -count=1, where the panic needs a previous iteration's t to still be referenced.